### PR TITLE
Fix Date.js toUniversalTime and toLocalTime

### DIFF
--- a/H5/H5/Resources/Date.js
+++ b/H5/H5/Resources/Date.js
@@ -117,7 +117,7 @@
                 d1 = new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate(), d.getUTCHours(), d.getUTCMinutes(), d.getUTCSeconds(), d.getUTCMilliseconds()));
 
                 d1.kind = 2;
-                d1.ticks = ticks;
+                d1.ticks = ticks.sub(this.$getTzOffset(d));
 
                 // Check if Ticks are out of range
                 if (d1.ticks.gt(this.getMaxTicks()) || d1.ticks.lt(0)) {

--- a/H5/H5/Resources/Date.js
+++ b/H5/H5/Resources/Date.js
@@ -147,7 +147,7 @@
                 d1 = new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate(), d.getUTCHours(), d.getUTCMinutes(), d.getUTCSeconds(), d.getUTCMilliseconds()));
 
                 d1.kind = 1;
-                d1.ticks = ticks;
+                d1.ticks = ticks.add(this.$getTzOffset(d));
 
                 // Check if Ticks are out of range
                 if (d1.ticks.gt(this.getMaxTicks()) || d1.ticks.lt(0)) {


### PR DESCRIPTION
Date.js toUniversalTime and toLocalTime are not applying the time zone offset to ticks when converting.

This change fixes that.

Note that bridge 17.6.0 did this correctly. I did not track down when it changed.

bridge 17.6.0 toUniversalTime:
![image](https://github.com/theolivenbaum/h5/assets/59707001/1c51c17c-5682-44e3-bbf8-52dc0a3811aa)
Note `mul(10000)` is not necessary as `$getTzOffset` now handles the multiply.