### PR TITLE
Sets sourceRoot in the source maps

### DIFF
--- a/H5/Compiler/Translator/SourceMaps/SourceMapGenerator.cs
+++ b/H5/Compiler/Translator/SourceMaps/SourceMapGenerator.cs
@@ -47,10 +47,10 @@ namespace H5.Translator
 
         internal static Regex tokenRegex = new Regex(@"/\*##\|(.+?),(\d+?),(\d+?)\|##\*/", RegexOptions.Compiled);
 
-        public static void Generate(string scriptFileName, string basePath, ref string content, Action<SourceMapBuilder> beforeGenerate, Func<string, string> sourceContent, string[] names, IList<string> sourceFiles, UnicodeNewline? forceEols)
+        public static void Generate(string scriptFileName, string sourceRoot, string basePath, ref string content, Action<SourceMapBuilder> beforeGenerate, Func<string, string> sourceContent, string[] names, IList<string> sourceFiles, UnicodeNewline? forceEols)
         {
             var fileName = Path.GetFileName(scriptFileName);
-            var generator = new SourceMapGenerator(fileName, "", basePath, forceEols);
+            var generator = new SourceMapGenerator(fileName, sourceRoot, basePath, forceEols);
             StringLocation location = null;
             string script = content;
             int offset = 0;

--- a/H5/Compiler/Translator/Translator/Translator.cs
+++ b/H5/Compiler/Translator/Translator/Translator.cs
@@ -398,8 +398,8 @@ namespace H5.Translator
             if (AssemblyInfo.SourceMap.Enabled)
             {
                 var projectPath = Path.GetDirectoryName(Location);
-
-                SourceMapGenerator.Generate(fileName, projectPath, ref content,
+                var sourceRoot = projectPath;
+                SourceMapGenerator.Generate(fileName, sourceRoot, projectPath, ref content,
                     before,
                     (sourceRelativePath) =>
                     {


### PR DESCRIPTION
Currently the source map generator sets the `sourceRoot` to the empty string. However, the `sources` are relative paths to the C# files from the project directory.

Example of current source map:
```
{
  "version": 3,
  "file": "MyCoolApp.js",
  "sourceRoot": "",
  "sources": [
    "App.cs",
    "views/LogTable.cs",
```

If building and debugging in the same repo (standard development workflow), the sourceRoot property should be set to the project path. This allows the debugger to locate the source files.

Example: for a project at "/MyRepo/Applications/MyCoolApp" the source map should be:
```
{
  "version": 3,
  "file": "MyCoolApp.js",
  "sourceRoot": "/MyRepo/Applications/MyCoolApp",
  "sources": [
    "App.cs",
    "views/LogTable.cs",
```

I tested these changes using vscode with chrome remote debugging and verified it was able to find my code files with the sourceRoot set.

There could be cases in which you might want the sourceRoot to be different than the project directory - E.g. building and debugging in different environments. However, I don't think leaving it empty makes sense. By defaulting to the project directory the source maps will work for most development workflows.