### PR TITLE
No longer add TimeSpan to the $jsonGuard of H5.Newtonsoft.Json

### DIFF
--- a/H5/H5.Newtonsoft.Json/Resources/Manual/JsonConvert.js
+++ b/H5/H5.Newtonsoft.Json/Resources/Manual/JsonConvert.js
@@ -483,6 +483,7 @@
                             type !== System.Decimal &&
                             type !== System.DateTime &&
                             type !== System.DateTimeOffset &&
+                            type !== System.TimeSpan &&
                             type !== System.Char &&
                             !H5.Reflection.isEnum(type)) {
                             H5.$jsonGuard.push(obj);


### PR DESCRIPTION
It looks like the check on type in the SerializeObject method of H5.Newtonsoft.Json is missing a check for TimeSpan. This PR adds this check to make sure that TimeSpan values are not added to the guard.