### PR TITLE
Add `userAgentData` to `Navigator` in H5.Core

### DIFF
--- a/H5/H5.Core/dom/dom.Navigator.cs
+++ b/H5/H5.Core/dom/dom.Navigator.cs
@@ -17,6 +17,105 @@ namespace H5.Core
 
         [CombinedClass]
         [FormerInterface]
+        public class NavigatorUABrandVersion : IObject
+        {
+            public virtual string brand
+            {
+                get;
+            }
+
+            public virtual string version
+            {
+                get;
+            }
+        }
+
+        [CombinedClass]
+        [FormerInterface]
+        public class UADataValues : IObject
+        {
+            public virtual es5.ReadonlyArray<dom.NavigatorUABrandVersion> brands
+            {
+                get;
+            }
+
+            public virtual bool mobile
+            {
+                get;
+            }
+
+            public virtual string platform
+            {
+                get;
+            }
+
+            public virtual string architecture
+            {
+                get;
+            }
+
+            public virtual string bitness
+            {
+                get;
+            }
+
+            public virtual es5.ReadonlyArray<string> formFactors
+            {
+                get;
+            }
+
+            public virtual es5.ReadonlyArray<dom.NavigatorUABrandVersion> fullVersionList
+            {
+                get;
+            }
+
+            public virtual string model
+            {
+                get;
+            }
+
+            public virtual string platformVersion
+            {
+                get;
+            }
+
+            public virtual string uaFullVersion
+            {
+                get;
+            }
+
+            public virtual bool wow64
+            {
+                get;
+            }
+        }
+
+        [CombinedClass]
+        [FormerInterface]
+        public class NavigatorUAData : IObject
+        {
+            public virtual es5.ReadonlyArray<dom.NavigatorUABrandVersion> brands
+            {
+                get;
+            }
+
+            public virtual bool mobile
+            {
+                get;
+            }
+
+            public virtual string platform
+            {
+                get;
+            }
+
+            public virtual extern es5.Promise<dom.UADataValues> getHighEntropyValues(string[] hints);
+
+            public virtual extern object toJSON();
+        }
+
+        [CombinedClass]
+        [FormerInterface]
         public class Clipboard : IObject
         {
             public static dom.Clipboard prototype
@@ -90,6 +189,11 @@ namespace H5.Core
             }
 
             public virtual string doNotTrack
+            {
+                get;
+            }
+
+            public virtual dom.NavigatorUAData userAgentData
             {
                 get;
             }

--- a/Tests/H5.Compiler.Service.Tests/CacheEdgeCasesTests.cs
+++ b/Tests/H5.Compiler.Service.Tests/CacheEdgeCasesTests.cs
@@ -65,7 +65,7 @@ namespace H5.Compiler.Service.Tests
                 Assert.AreEqual(1, stats["ReusedFiles"], "Should invalidate App. (2 source files - 1 emitted type = 1 'reused' count artifact)");
 
                 // Verify content to be sure
-                var js = result2.Output.Values.FirstOrDefault(v => v.Contains("Changed"));
+                var js = result2.Output.Values.FirstOrDefault(v => System.Text.Encoding.UTF8.GetString(v.ToArray()).Contains("Changed"));
                 Assert.IsNotNull(js, "Output should contain the changed string");
             }
         }


### PR DESCRIPTION
Adds the `userAgentData` property to the `navigator` class in `H5.Core`, mapping the browser's User-Agent Client Hints API.

Includes mapping for associated types:
- `NavigatorUAData` (low entropy data and `getHighEntropyValues` promise method)
- `UADataValues` (high entropy data hints)
- `NavigatorUABrandVersion` (brand and version arrays)

---
*PR created automatically by Jules for task [13012010764597317514](https://jules.google.com/task/13012010764597317514) started by @theolivenbaum*