### PR TITLE
Fix Convert.ChangeType failure for System.Nullable types

### DIFF
--- a/H5/Compiler/Translator/Emitter/Blocks/FieldBlock.cs
+++ b/H5/Compiler/Translator/Emitter/Blocks/FieldBlock.cs
@@ -184,7 +184,8 @@ namespace H5.Translator
                         {
                             try
                             {
-                                constValue = Convert.ChangeType(constValue, ReflectionHelper.GetTypeCode(expectedType));
+                                var targetType = NullableType.IsNullable(expectedType) ? NullableType.GetUnderlyingType(expectedType) : expectedType;
+                                constValue = Convert.ChangeType(constValue, ReflectionHelper.GetTypeCode(targetType));
                             }
                             catch (Exception)
                             {


### PR DESCRIPTION
Fixes an issue where the C# compiler (H5 translator) fails and logs a warning (`FieldBlock: Convert.ChangeType is failed. Value type: Mosaik.Schema.SortModeEnum, Target type: System.Nullable`) when trying to convert a constant value (e.g., an enum) into a `System.Nullable` target type.

`Convert.ChangeType` does not natively support converting to `Nullable<T>`. This change unwraps the expected type to its underlying type before requesting the type code, allowing the conversion to succeed safely.

---
*PR created automatically by Jules for task [14032229011225003759](https://jules.google.com/task/14032229011225003759) started by @theolivenbaum*