### PR TITLE
Fix missing parentheses when converting ConditionalAccessExpression to JS inside IsPatternExpression

### DIFF
--- a/H5/Compiler/Translator/Utils/Roslyn/SharpSixRewriter.cs
+++ b/H5/Compiler/Translator/Utils/Roslyn/SharpSixRewriter.cs
@@ -5030,7 +5030,8 @@ namespace H5.Translator
                                      || node.Parent is CastExpressionSyntax
                                      || node.Parent is AwaitExpressionSyntax
                                      || node.Parent is PostfixUnaryExpressionSyntax
-                                     || node.Parent is PrefixUnaryExpressionSyntax;
+                                     || node.Parent is PrefixUnaryExpressionSyntax
+                                     || node.Parent is IsPatternExpressionSyntax;
 
             node = (ConditionalAccessExpressionSyntax)base.VisitConditionalAccessExpression(node);
             var idx = 0;

--- a/Tests/H5.Compiler.IntegrationTests/Language/CSharp9Tests.cs
+++ b/Tests/H5.Compiler.IntegrationTests/Language/CSharp9Tests.cs
@@ -36,6 +36,35 @@ public class Program
         }
 
         [TestMethod]
+        public async Task ConditionalAccessWithIsPattern()
+        {
+            var code = """
+using System;
+
+public class Program
+{
+    class Stats {
+        public object DetailedStats { get; set; }
+    }
+
+    public static void Main()
+    {
+        Stats stats = null;
+        if (stats?.DetailedStats is null) {
+            Console.WriteLine("Null");
+        }
+        stats = new Stats();
+        if (stats?.DetailedStats is null) {
+            Console.WriteLine("Null2");
+        }
+    }
+}
+""";
+            var output = await RunTest(code);
+            Assert.AreEqual("Null\nNull2", output);
+        }
+
+        [TestMethod]
         public async Task Records_2()
         {
             var code = """


### PR DESCRIPTION
This fixes a bug where `if (stats?.DetailedStats is null)` was generating invalid Javascript (`stats != null ? stats.DetailedStats : null == null` instead of `(stats != null ? stats.DetailedStats : null) == null`). This was due to `SharpSixRewriter.VisitConditionalAccessExpression` omitting parentheses around the newly constructed `ConditionalExpression` when its parent is `IsPatternExpressionSyntax`.

A test case has been added to verify this fix in `CSharp9Tests.cs`.

---
*PR created automatically by Jules for task [2098653894040584861](https://jules.google.com/task/2098653894040584861) started by @theolivenbaum*