### PR TITLE
Modernize H5 module output via h5.json `outputModuleType`

### DIFF
--- a/H5/Compiler/Contract/Config/IAssemblyInfo.cs
+++ b/H5/Compiler/Contract/Config/IAssemblyInfo.cs
@@ -20,6 +20,9 @@ namespace H5.Contract
         [JsonConverter(typeof(StringEnumConverter))]
         JavaScriptOutputType OutputFormatting{ get; set; }
 
+        [JsonConverter(typeof(StringEnumConverter))]
+        OutputModuleType OutputModuleType{ get; set; }
+
         Module Module{ get; set; }
 
         string Output{ get; set; }

--- a/H5/Compiler/Contract/Config/OutputModuleType.cs
+++ b/H5/Compiler/Contract/Config/OutputModuleType.cs
@@ -1,0 +1,23 @@
+namespace H5.Contract
+{
+    /// <summary>
+    /// Controls how generated JavaScript output is packaged.
+    /// </summary>
+    public enum OutputModuleType
+    {
+        /// <summary>
+        /// Default H5 output: every type is registered through global <c>H5.define</c> /
+        /// <c>H5.assembly</c> calls. Files are emitted with a <c>.js</c> extension.
+        /// </summary>
+        Default = 0,
+
+        /// <summary>
+        /// Modern ES module output. Files are emitted with a <c>.mjs</c> extension and
+        /// the generated assembly registration is wrapped in a top-level
+        /// <c>import { H5 } from "./h5.mjs"</c> / <c>export { H5 }</c> pair so the
+        /// resulting files can be consumed directly by browsers or bundlers as ES
+        /// modules.
+        /// </summary>
+        ESM = 1,
+    }
+}

--- a/H5/Compiler/Contract/Constants/Files.cs
+++ b/H5/Compiler/Contract/Constants/Files.cs
@@ -5,6 +5,7 @@
         public class Extensions
         {
             public const string JS = ".js";
+            public const string MJS = ".mjs";
             public const string MinJS = ".min.js";
             public const string DTS = ".d.ts";
             public const string CSS = ".css";

--- a/H5/Compiler/Contract/H5Type.cs
+++ b/H5/Compiler/Contract/H5Type.cs
@@ -1176,22 +1176,10 @@ namespace H5.Contract
             var module = typeInfo.Module;
             string moduleName = null;
 
-            if (module != null && module.Type == ModuleType.UMD)
-            {
-                if (!module.PreventModuleName)
-                {
-                    moduleName = module.ExportAsNamespace;
-                }
-
-                if (!String.IsNullOrEmpty(moduleName))
-                {
-                    ns = string.IsNullOrWhiteSpace(ns) ? moduleName : (moduleName + "." + ns);
-                }
-                else
-                {
-                    module = null;
-                }
-            }
+            // The legacy UMD-specific filename prefixing was removed along with the
+            // AMD / CommonJS / UMD module types. Named modules are now emitted via
+            // OutputModuleType=ESM (h5.json) and rely on the module's own
+            // ExportAsNamespace / file-grouping rules below.
 
             switch (emitter.AssemblyInfo.FileNameCasing)
             {

--- a/H5/Compiler/Contract/ILoader.cs
+++ b/H5/Compiler/Contract/ILoader.cs
@@ -1,11 +1,14 @@
 namespace H5.Contract
 {
+    /// <summary>
+    /// Retained for source compatibility. The legacy AMD / CommonJS / ES6 loader
+    /// selectors have been removed; the packaging of generated JavaScript is now
+    /// controlled via <c>OutputModuleType</c> in <c>h5.json</c>.
+    /// </summary>
     public enum ModuleLoaderType
     {
-        AMD,
-        CommonJS,
-        ES6,
-        Global
+        /// <summary>The only supported value.</summary>
+        Global = 0,
     }
 
     public interface IModuleLoader

--- a/H5/Compiler/Contract/ModuleDependency.cs
+++ b/H5/Compiler/Contract/ModuleDependency.cs
@@ -54,7 +54,7 @@ namespace H5.Contract
         public Module(string name, IEmitter emitter, bool preventModuleName = false)
         {
             Name = name;
-            Type = ModuleType.AMD;
+            Type = ModuleType.ESM;
             PreventModuleName = preventModuleName;
             Emitter = emitter;
             InitName();
@@ -73,7 +73,7 @@ namespace H5.Contract
         public Module()
         {
             Name = "";
-            Type = ModuleType.AMD;
+            Type = ModuleType.ESM;
             PreventModuleName = false;
             InitName();
         }
@@ -193,11 +193,15 @@ namespace H5.Contract
         }
     }
 
+    /// <summary>
+    /// Retained for source compatibility with the historical <c>[Module]</c> attribute.
+    /// The packaging of generated JavaScript is now driven by <c>OutputModuleType</c> in
+    /// <c>h5.json</c> (either the default <c>H5.define</c> output or modern ES modules
+    /// emitted as <c>.mjs</c>), so <c>[Module]</c> only carries naming information.
+    /// </summary>
     public enum ModuleType
     {
-        AMD,
-        CommonJS,
-        UMD,
-        ES6
+        /// <summary>Default / unspecified.</summary>
+        ESM = 0,
     }
 }

--- a/H5/Compiler/Translator/Emitter/Blocks/EmitBlock.cs
+++ b/H5/Compiler/Translator/Emitter/Blocks/EmitBlock.cs
@@ -292,11 +292,21 @@ namespace H5.Translator
                 }
             }
 
-            // Append '.js' extension to file name at translator.Outputs level: this aids in code grouping on files
-            // when filesystem is not case sensitive.
+            // Append '.js' (or '.mjs' when ESM output is selected) extension to file name at translator.Outputs
+            // level: this aids in code grouping on files when filesystem is not case sensitive.
+            var isEsmOutput = Emitter.AssemblyInfo.OutputModuleType == OutputModuleType.ESM;
+            var jsExtension = isEsmOutput ? Files.Extensions.MJS : Files.Extensions.JS;
+
             if (!FileHelper.IsJS(fileName))
             {
-                fileName += Files.Extensions.JS;
+                fileName += jsExtension;
+            }
+            else if (isEsmOutput && fileName.EndsWith(Files.Extensions.JS, System.StringComparison.OrdinalIgnoreCase) && !fileName.EndsWith(Files.Extensions.MJS, System.StringComparison.OrdinalIgnoreCase))
+            {
+                // The user specified a `.js` file name in h5.json / FileName attribute,
+                // but ESM output was requested — swap the extension so the emitted file
+                // matches the module format.
+                fileName = fileName.Substring(0, fileName.Length - Files.Extensions.JS.Length) + Files.Extensions.MJS;
             }
 
             switch (Emitter.AssemblyInfo.FileNameCasing)

--- a/H5/Compiler/Translator/Emitter/Blocks/InlineArgumentsBlock.cs
+++ b/H5/Compiler/Translator/Emitter/Blocks/InlineArgumentsBlock.cs
@@ -433,8 +433,7 @@ namespace H5.Translator
 
                     if (exprs.Count > 0)
                     {
-                        var amd = new List<string>();
-                        var cjs = new List<string>();
+                        var moduleNames = new List<string>();
                         foreach (var expr in exprs)
                         {
                             if (!(Emitter.Resolver.ResolveNode(expr) is TypeOfResolveResult rr))
@@ -455,39 +454,33 @@ namespace H5.Translator
                                 module = h5Type.TypeInfo.Module;
                             }
 
-                            AddModuleByType(amd, cjs, module);
+                            if (module != null)
+                            {
+                                moduleNames.Add(module.Name);
+                            }
                         }
 
                         Write("{");
 
-                        if (amd.Count > 0)
+                        if (moduleNames.Count > 0)
                         {
-                            Write("amd: ");
-                            Write(Emitter.ToJavaScript(amd.ToArray()));
-                            if (cjs.Count > 0)
-                            {
-                                Write(", ");
-                            }
-                        }
-
-                        if (cjs.Count > 0)
-                        {
-                            Write("cjs: ");
-                            Write(Emitter.ToJavaScript(cjs.ToArray()));
+                            Write("modules: ");
+                            Write(Emitter.ToJavaScript(moduleNames.ToArray()));
                         }
 
                         if (!string.IsNullOrWhiteSpace(Emitter.AssemblyInfo.Loader.FunctionName))
                         {
-                            Write(", ");
+                            if (moduleNames.Count > 0)
+                            {
+                                Write(", ");
+                            }
                             Write(Emitter.ToJavaScript(Emitter.AssemblyInfo.Loader.FunctionName));
                         }
 
                         Write("}, function () { ");
 
                         var idx = 0;
-                        var list = amd.Concat(cjs);
-
-                        foreach (var moduleName in list)
+                        foreach (var moduleName in moduleNames)
                         {
                             Write(moduleName);
                             Write(" = arguments[");
@@ -1191,26 +1184,6 @@ namespace H5.Translator
             }
 
             return H5Types.ToJsName(enumType, Emitter);
-        }
-
-        public void AddModuleByType(List<string> amd, List<string> cjs, Module module)
-        {
-            if (module != null)
-            {
-                if (!(module.Type == ModuleType.UMD &&
-                     Emitter.AssemblyInfo.Loader.Type == ModuleLoaderType.Global))
-                {
-                    if (module.Type == ModuleType.AMD
-                        || (module.Type == ModuleType.UMD && Emitter.AssemblyInfo.Loader.Type == ModuleLoaderType.AMD))
-                    {
-                        amd.Add(module.Name);
-                    }
-                    else
-                    {
-                        cjs.Add(module.Name);
-                    }
-                }
-            }
         }
 
         private void WriteGetType(bool needName, IType type, AstNode node, string modifier)

--- a/H5/Compiler/Translator/Emitter/Emitter.Output.cs
+++ b/H5/Compiler/Translator/Emitter/Emitter.Output.cs
@@ -189,6 +189,7 @@ namespace H5.Translator
 
             var level = InitialLevel;
             StringBuilder endOutput = new StringBuilder();
+            var isEsm = AssemblyInfo.OutputModuleType == OutputModuleType.ESM;
 
             if (output.NonModuletOutput.Length > 0 || output.ModuleOutput.Count > 0)
             {
@@ -200,6 +201,13 @@ namespace H5.Translator
                                          Translator.ProjectProperties.AssemblyName;
 
                         OutputAssemblyComment(tmp);
+
+                        if (isEsm)
+                        {
+                            WriteNewLine(tmp, "import { H5 } from \"./h5.mjs\";");
+                            WriteNewLine(tmp);
+                        }
+
                         if(!string.IsNullOrEmpty(Translator.ProjectProperties.AssemblyVersion))
                         {
                             tmp.Append(JS.Types.H5.ASSEMBLYVERSION + "(");
@@ -271,6 +279,12 @@ namespace H5.Translator
                 {
                     tmp.Append("});");
                     WriteNewLine(tmp);
+
+                    if (isEsm)
+                    {
+                        WriteNewLine(tmp);
+                        WriteNewLine(tmp, "export { H5 };");
+                    }
                 }
             }
 
@@ -306,59 +320,13 @@ namespace H5.Translator
                     WriteNewLine(tmp);
                 }
 
-                var type = loader.Type;
-                var amd = dependencies.Where(d => d.Type == ModuleType.AMD || ((d.Type == null || d.Type == ModuleType.UMD) && type == ModuleLoaderType.AMD)).ToList();
-                var cjs = dependencies.Where(d => d.Type == ModuleType.CommonJS || ((d.Type == null || d.Type == ModuleType.UMD) && type == ModuleLoaderType.CommonJS)).ToList();
-                var es6 = dependencies.Where(d => d.Type == ModuleType.ES6 || (d.Type == null && type == ModuleLoaderType.ES6)).ToList();
-
-                if (amd.Count > 0)
+                // When the user opted into ES module output via h5.json, emit standard
+                // top-level `import` statements for every tracked dependency. Otherwise
+                // the legacy h5.define / H5.assembly wrapping handles dependencies
+                // implicitly, so nothing extra needs to be emitted here.
+                if (AssemblyInfo.OutputModuleType == OutputModuleType.ESM && dependencies.Count > 0)
                 {
-                    WriteIndent(tmp, level);
-                    tmp.Append(loader.FunctionName ?? "require");
-                    tmp.Append("([");
-
-                    amd.Each(md =>
-                    {
-                        tmp.Append(ToJavaScript(md.DependencyName));
-                        tmp.Append(", ");
-                    });
-                    tmp.Remove(tmp.Length - 2, 2); // remove trailing comma
-                    tmp.Append("], function (");
-
-                    amd.Each(md =>
-                    {
-                        tmp.Append(md.VariableName.IsNotEmpty() ? md.VariableName : md.DependencyName);
-                        tmp.Append(", ");
-                    });
-                    tmp.Remove(tmp.Length - 2, 2); // remove trailing comma
-
-                    WriteNewLine(tmp, ") {");
-
-                    WriteIndent(endOutput, level);
-                    WriteNewLine(endOutput, JS.Types.H5.INIT + "();");
-                    WriteIndent(endOutput, level);
-                    WriteNewLine(endOutput, "});");
-                    level++;
-                }
-
-                if (cjs.Count > 0)
-                {
-                    cjs.Each(md =>
-                    {
-                        WriteIndent(tmp, level);
-                        tmp.AppendFormat("var {0} = require(\"{1}\");", md.VariableName.IsNotEmpty() ? md.VariableName : md.DependencyName, md.DependencyName);
-                        WriteNewLine(tmp);
-                    });
-
-                    if (es6.Count == 0)
-                    {
-                        WriteNewLine(tmp);
-                    }
-                }
-
-                if (es6.Count > 0)
-                {
-                    es6.Each(md =>
+                    dependencies.Each(md =>
                     {
                         WriteIndent(tmp, level);
                         WriteNewLine(tmp, "import " + (md.VariableName.IsNotEmpty() ? md.VariableName : md.DependencyName) + " from " + ToJavaScript(md.DependencyName) + ";");

--- a/H5/Compiler/Translator/Emitter/Emitter.OutputModule.cs
+++ b/H5/Compiler/Translator/Emitter/Emitter.OutputModule.cs
@@ -20,6 +20,8 @@ namespace H5.Translator
         {
             using (var m = new Measure(Logger, "Wrapping to modules", logLevel: LogLevel.Trace))
             {
+                var isEsm = AssemblyInfo.OutputModuleType == OutputModuleType.ESM;
+
                 foreach (var outputPair in Outputs)
                 {
                     CancellationToken.ThrowIfCancellationRequested();
@@ -35,85 +37,17 @@ namespace H5.Translator
 
                         AbstractEmitterBlock.RemovePenultimateEmptyLines(moduleOutput, true);
 
-                        switch (module.Type)
+                        if (isEsm)
                         {
-                            case ModuleType.CommonJS:
-                                WrapToCommonJS(moduleOutput, module, output);
-                                break;
-                            case ModuleType.UMD:
-                                WrapToUMD(moduleOutput, module, output);
-                                break;
-                            case ModuleType.ES6:
-                                WrapToES6(moduleOutput, module, output);
-                                break;
-                            case ModuleType.AMD:
-                            default:
-                                WrapToAMD(moduleOutput, module, output);
-                                break;
+                            WrapToESM(moduleOutput, module, output);
+                        }
+                        else
+                        {
+                            WrapToH5Define(moduleOutput, module, output);
                         }
                     }
                 }
             }
-        }
-
-        protected void WrapToAMD(StringBuilder moduleOutput, Module module, IEmitterOutput output)
-        {
-            var str = moduleOutput.ToString();
-            moduleOutput.Length = 0;
-
-            WriteIndent(moduleOutput, InitialLevel);
-            moduleOutput.Append(JS.Funcs.DEFINE + "(");
-
-            if (!module.NoName)
-            {
-                moduleOutput.Append(ToJavaScript(module.OriginalName));
-                moduleOutput.Append(", ");
-            }
-
-            var enabledDependecies = GetEnabledDependecies(module, output);
-
-            if (enabledDependecies.Count > 0)
-            {
-                moduleOutput.Append("[");
-                enabledDependecies.Each(md =>
-                {
-                    moduleOutput.Append(ToJavaScript(md.DependencyName));
-                    moduleOutput.Append(", ");
-                });
-                moduleOutput.Remove(moduleOutput.Length - 2, 2); // remove trailing comma
-                moduleOutput.Append("], ");
-            }
-
-            moduleOutput.Append("function (");
-
-            if (enabledDependecies.Count > 0)
-            {
-                enabledDependecies.Each(md =>
-                {
-                    moduleOutput.Append(md.VariableName.IsNotEmpty() ? md.VariableName : md.DependencyName);
-                    moduleOutput.Append(", ");
-                });
-                moduleOutput.Remove(moduleOutput.Length - 2, 2); // remove trailing comma
-            }
-
-            WriteNewLine(moduleOutput, ") {");
-
-            WriteIndent(moduleOutput, InitialLevel);
-            WriteNewLine(moduleOutput, INDENT + "var " + module.Name + " = { };");
-            moduleOutput.Append(str);
-
-            if (!str.Trim().EndsWith(NEW_LINE))
-            {
-                WriteNewLine(moduleOutput);
-            }
-
-            WriteIndent(moduleOutput, InitialLevel);
-            WriteNewLine(moduleOutput, INDENT + "H5.init();");
-
-            WriteIndent(moduleOutput, InitialLevel);
-            WriteNewLine(moduleOutput, INDENT + "return " + module.Name + ";");
-            WriteIndent(moduleOutput, InitialLevel);
-            WriteNewLine(moduleOutput, "});");
         }
 
         private List<IModuleDependency> GetEnabledDependecies(Module module, IEmitterOutput output)
@@ -128,155 +62,12 @@ namespace H5.Translator
             return new List<IModuleDependency>();
         }
 
-        protected void WrapToCommonJS(StringBuilder moduleOutput, Module module, IEmitterOutput output)
-        {
-            var str = moduleOutput.ToString();
-            moduleOutput.Length = 0;
-
-            moduleOutput.Append(INDENT);
-            moduleOutput.Append("(function (");
-
-            var enabledDependecies = GetEnabledDependecies(module, output);
-
-            if (enabledDependecies.Count > 0)
-            {
-                enabledDependecies.Each(md =>
-                {
-                    moduleOutput.Append(md.VariableName.IsNotEmpty() ? md.VariableName : md.DependencyName);
-                    moduleOutput.Append(", ");
-                });
-                moduleOutput.Remove(moduleOutput.Length - 2, 2); // remove trailing comma
-            }
-
-            WriteNewLine(moduleOutput, ") {");
-            moduleOutput.Append(INDENT);
-            WriteIndent(moduleOutput, InitialLevel);
-            WriteNewLine(moduleOutput, "var " + module.Name + " = { };");
-            moduleOutput.Append(str);
-
-            if (!str.Trim().EndsWith(NEW_LINE))
-            {
-                WriteNewLine(moduleOutput);
-            }
-
-            WriteIndent(moduleOutput, InitialLevel);
-            WriteNewLine(moduleOutput, INDENT + "module.exports." + module.Name + " = " + module.Name + ";");
-            WriteIndent(moduleOutput, InitialLevel);
-            moduleOutput.Append("}) (");
-
-            if (enabledDependecies.Count > 0)
-            {
-                enabledDependecies.Each(md =>
-                {
-                    moduleOutput.Append("require(" + ToJavaScript(md.DependencyName) + "), ");
-                });
-                moduleOutput.Remove(moduleOutput.Length - 2, 2); // remove trailing comma
-            }
-
-            WriteNewLine(moduleOutput, ");");
-        }
-
-        protected void WrapToUMD(StringBuilder moduleOutput, Module module, IEmitterOutput output)
-        {
-            var str = moduleOutput.ToString();
-            moduleOutput.Length = 0;
-
-            WriteIndent(moduleOutput, 1);
-            WriteNewLine(moduleOutput, "(function (root, factory) {");
-            WriteIndent(moduleOutput, 2);
-            WriteNewLine(moduleOutput, "if (typeof define === 'function' && define.amd) {");
-            WriteIndent(moduleOutput, 3);
-            moduleOutput.Append(JS.Funcs.DEFINE + "(");
-            if (!module.NoName)
-            {
-                moduleOutput.Append(ToJavaScript(module.OriginalName));
-                moduleOutput.Append(", ");
-            }
-
-            var enabledDependecies = GetEnabledDependecies(module, output);
-
-            if (enabledDependecies.Count > 0)
-            {
-                moduleOutput.Append("[");
-                enabledDependecies.Each(md =>
-                {
-                    moduleOutput.Append(ToJavaScript(md.DependencyName));
-                    moduleOutput.Append(", ");
-                });
-                moduleOutput.Remove(moduleOutput.Length - 2, 2); // remove trailing comma
-                moduleOutput.Append("], ");
-            }
-            WriteNewLine(moduleOutput, "factory);");
-
-            WriteIndent(moduleOutput, 2);
-            WriteNewLine(moduleOutput, "} else if (typeof module === 'object' && module.exports) {");
-            WriteIndent(moduleOutput, 3);
-            moduleOutput.Append("module.exports = factory(");
-            if (enabledDependecies.Count > 0)
-            {
-                enabledDependecies.Each(md =>
-                {
-                    moduleOutput.Append("require(" + ToJavaScript(md.DependencyName) + "), ");
-                });
-                moduleOutput.Remove(moduleOutput.Length - 2, 2);
-            }
-
-            WriteNewLine(moduleOutput, ");");
-
-            WriteIndent(moduleOutput, 2);
-            WriteNewLine(moduleOutput, "} else {");
-            WriteIndent(moduleOutput, 3);
-            moduleOutput.Append("root[" + ToJavaScript(module.OriginalName) + "] = factory(");
-
-            if (enabledDependecies.Count > 0)
-            {
-                enabledDependecies.Each(md =>
-                {
-                    moduleOutput.Append("root[" + ToJavaScript(md.DependencyName) + "], ");
-                });
-                moduleOutput.Remove(moduleOutput.Length - 2, 2); // remove trailing comma
-            }
-
-            WriteNewLine(moduleOutput, ");");
-            WriteIndent(moduleOutput, 2);
-            WriteNewLine(moduleOutput, "}");
-
-            WriteIndent(moduleOutput, 1);
-            moduleOutput.Append("}(this, function (");
-
-            if (enabledDependecies.Count > 0)
-            {
-                enabledDependecies.Each(md =>
-                {
-                    moduleOutput.Append(md.VariableName ?? md.DependencyName);
-                    moduleOutput.Append(", ");
-                });
-                moduleOutput.Remove(moduleOutput.Length - 2, 2); // remove trailing comma
-            }
-
-            moduleOutput.Append(") {");
-            WriteNewLine(moduleOutput);
-
-            WriteIndent(moduleOutput, 2);
-            WriteNewLine(moduleOutput, "var " + module.Name + " = { };");
-            moduleOutput.Append(str);
-
-            if (!str.Trim().EndsWith(NEW_LINE))
-            {
-                WriteNewLine(moduleOutput);
-            }
-
-            WriteIndent(moduleOutput, 2);
-            WriteNewLine(moduleOutput, "H5.init();");
-
-            WriteIndent(moduleOutput, 2);
-            WriteNewLine(moduleOutput, "return " + module.Name + ";");
-
-            WriteIndent(moduleOutput, 1);
-            WriteNewLine(moduleOutput, "}));");
-        }
-
-        protected void WrapToES6(StringBuilder moduleOutput, Module module, IEmitterOutput output)
+        /// <summary>
+        /// Legacy <c>H5.define</c> module wrap. Wraps the module content in an IIFE that
+        /// builds the named module object and exposes it through the existing global
+        /// H5 namespace. Used when <see cref="OutputModuleType.Default"/> is selected.
+        /// </summary>
+        protected void WrapToH5Define(StringBuilder moduleOutput, Module module, IEmitterOutput output)
         {
             var str = moduleOutput.ToString();
             moduleOutput.Length = 0;
@@ -284,21 +75,48 @@ namespace H5.Translator
             moduleOutput.Append(INDENT);
             WriteNewLine(moduleOutput, "(function () {");
 
-            moduleOutput.Append(INDENT);
             WriteIndent(moduleOutput, InitialLevel);
-            WriteNewLine(moduleOutput, "var " + module.Name + " = { };");
+            WriteNewLine(moduleOutput, INDENT + "var " + module.Name + " = { };");
+            moduleOutput.Append(str);
+
+            if (!str.Trim().EndsWith(NEW_LINE))
+            {
+                WriteNewLine(moduleOutput);
+            }
+
+            WriteIndent(moduleOutput, InitialLevel);
+            WriteNewLine(moduleOutput, INDENT + JS.Types.H5.INIT + "();");
+
+            WriteIndent(moduleOutput, InitialLevel);
+            moduleOutput.Append("}) ();");
+            WriteNewLine(moduleOutput);
+        }
+
+        /// <summary>
+        /// Modern ES module wrap. Emits top-level <c>import</c> statements for the module's
+        /// dependencies and an <c>export</c> for the module object. Used when
+        /// <see cref="OutputModuleType.ESM"/> is selected.
+        /// </summary>
+        protected void WrapToESM(StringBuilder moduleOutput, Module module, IEmitterOutput output)
+        {
+            var str = moduleOutput.ToString();
+            moduleOutput.Length = 0;
 
             var enabledDependecies = GetEnabledDependecies(module, output);
 
+            foreach (var md in enabledDependecies)
+            {
+                WriteIndent(moduleOutput, InitialLevel);
+                WriteNewLine(moduleOutput, "import " + (md.VariableName.IsNotEmpty() ? md.VariableName : md.DependencyName) + " from " + ToJavaScript(md.DependencyName) + ";");
+            }
+
             if (enabledDependecies.Count > 0)
             {
-                enabledDependecies.Each(md =>
-                {
-                    moduleOutput.Append(INDENT);
-                    WriteIndent(moduleOutput, InitialLevel);
-                    WriteNewLine(moduleOutput, "import " + (md.VariableName.IsNotEmpty() ? md.VariableName : md.DependencyName) + " from " + ToJavaScript(md.DependencyName) + ";");
-                });
+                WriteNewLine(moduleOutput);
             }
+
+            WriteIndent(moduleOutput, InitialLevel);
+            WriteNewLine(moduleOutput, "var " + module.Name + " = { };");
 
             moduleOutput.Append(str);
 
@@ -308,11 +126,7 @@ namespace H5.Translator
             }
 
             WriteIndent(moduleOutput, InitialLevel);
-            WriteNewLine(moduleOutput, INDENT + "export {" + module.Name + "};");
-            WriteIndent(moduleOutput, InitialLevel);
-            moduleOutput.Append("}) (");
-
-            WriteNewLine(moduleOutput, ");");
+            WriteNewLine(moduleOutput, "export { " + module.Name + " };");
         }
     }
 }

--- a/H5/Compiler/Translator/Emitter/TypeScript/EmitBlock.cs
+++ b/H5/Compiler/Translator/Emitter/TypeScript/EmitBlock.cs
@@ -88,7 +88,7 @@ namespace H5.Translator.TypeScript
 
                 if (ns != null)
                 {
-                    if (module == null || module.Type == ModuleType.UMD)
+                    if (module == null)
                     {
                         output.Append("declare ");
                     }
@@ -172,31 +172,17 @@ namespace H5.Translator.TypeScript
 
         private string WrapModule(KeyValuePair<Module, string> item)
         {
+            // Named modules emit a `declare module "name" { ... }` block so generated
+            // .d.ts files describe the ES module shape that h5 produces when
+            // OutputModuleType=ESM is selected. The legacy AMD / CommonJS / UMD
+            // variants have been removed — only the ESM-style declaration remains.
             StringBuilder sb = new StringBuilder();
 
-            if (item.Key.Type == ModuleType.AMD || item.Key.Type == ModuleType.CommonJS)
-            {
-                sb.Append("declare module \"" + item.Key.ExportAsNamespace + "\" {");
-                sb.Append(H5.Translator.Emitter.NEW_LINE);
-                sb.Append("    " + WriteIndentToString(item.Value, 1));
-                sb.Append(H5.Translator.Emitter.NEW_LINE);
-                sb.Append("}");
-            }
-            else if (item.Key.Type == ModuleType.UMD)
-            {
-                sb.Append(item.Value);
-                sb.Append(H5.Translator.Emitter.NEW_LINE);
-                sb.Append("declare module \"" + item.Key.ExportAsNamespace + "\" {");
-                sb.Append(H5.Translator.Emitter.NEW_LINE);
-                sb.Append("    export = " + item.Key.ExportAsNamespace + ";");
-                sb.Append(H5.Translator.Emitter.NEW_LINE);
-                sb.Append("}");
-            }
-            else
-            {
-                sb.Append(item.Value);
-            }
-
+            sb.Append("declare module \"" + item.Key.ExportAsNamespace + "\" {");
+            sb.Append(H5.Translator.Emitter.NEW_LINE);
+            sb.Append("    " + WriteIndentToString(item.Value, 1));
+            sb.Append(H5.Translator.Emitter.NEW_LINE);
+            sb.Append("}");
             sb.Append(H5.Translator.Emitter.NEW_LINE);
 
             return sb.ToString();

--- a/H5/Compiler/Translator/Translator/Translator.Output.cs
+++ b/H5/Compiler/Translator/Translator/Translator.Output.cs
@@ -465,6 +465,44 @@ namespace H5.Translator
             {
                 ExtractResources(outputPath, projectPath);
                 ExtractLocales(outputPath);
+                ExtractEsmShimsIfNeeded();
+            }
+        }
+
+        /// <summary>
+        /// When the project requests ES module output (h5.json
+        /// <c>"outputModuleType": "ESM"</c>) the generated <c>.mjs</c> files use
+        /// top-level <c>import { H5 } from "./h5.mjs"</c>. The H5 runtime itself
+        /// (<c>h5.js</c>) is still a plain IIFE that installs the global <c>H5</c>
+        /// object, so emit a tiny <c>h5.mjs</c> shim alongside it that re-exports
+        /// the global as a real ES module binding.
+        /// </summary>
+        private void ExtractEsmShimsIfNeeded()
+        {
+            if (AssemblyInfo.OutputModuleType != H5.Contract.OutputModuleType.ESM)
+            {
+                return;
+            }
+
+            var shimFiles = new (string Name, string Global)[]
+            {
+                ("h5.mjs", "H5"),
+                ("h5.min.mjs", "H5"),
+            };
+
+            // The shim deliberately imports h5.js for its side effects (installing
+            // the global H5 binding) and then re-exports it as an ES module export
+            // so the generated assembly bundles can use a clean
+            // `import { H5 } from "./h5.mjs"`.
+            foreach (var (fileName, globalName) in shimFiles)
+            {
+                var jsCounterpart = fileName.EndsWith(".min.mjs", StringComparison.OrdinalIgnoreCase) ? "h5.min.js" : "h5.js";
+
+                var shim = "import \"./" + jsCounterpart + "\";\n" +
+                           "const " + globalName + " = globalThis." + globalName + ";\n" +
+                           "export { " + globalName + " };\n";
+
+                Emitter.AddOutputItem(Outputs.References, fileName, new StringBuilder(shim), TranslatorOutputKind.Reference, location: null);
             }
         }
 

--- a/H5/Compiler/Translator/Utils/AssemblyInfo.cs
+++ b/H5/Compiler/Translator/Utils/AssemblyInfo.cs
@@ -96,6 +96,13 @@ namespace H5.Translator
         }
 
         /// <summary>
+        /// Selects how the generated JavaScript is packaged. <see cref="Contract.OutputModuleType.Default"/>
+        /// keeps the historical <c>H5.define</c> output written as <c>.js</c>. <see cref="Contract.OutputModuleType.ESM"/>
+        /// emits ES modules with a <c>.mjs</c> extension.
+        /// </summary>
+        public OutputModuleType OutputModuleType { get; set; } = OutputModuleType.Default;
+
+        /// <summary>
         /// Substrings the file name starting with the defined index.
         /// For example, it might be useful to get rid of the first namespace in the chain if use ByFullName or ByNamespace FilesHierarchy.
         /// </summary>

--- a/H5/Compiler/Translator/Utils/FileHelper.cs
+++ b/H5/Compiler/Translator/Utils/FileHelper.cs
@@ -29,6 +29,12 @@ namespace H5.Translator
                 return fileName;
             }
 
+            if (IsMJS(fileName))
+            {
+                // ESM output keeps the `.mjs` extension and inserts `.min` before it.
+                return fileName.ReplaceLastInstanceOf(Files.Extensions.MJS, ".min" + Files.Extensions.MJS);
+            }
+
             var s = fileName.ReplaceLastInstanceOf(Files.Extensions.JS, Files.Extensions.MinJS);
 
             if (!IsMinJS(s))
@@ -63,7 +69,18 @@ namespace H5.Translator
                 return false;
             }
 
-            return fileName.EndsWith(Files.Extensions.JS, StringComparison.InvariantCultureIgnoreCase);
+            return fileName.EndsWith(Files.Extensions.JS, StringComparison.InvariantCultureIgnoreCase)
+                || fileName.EndsWith(Files.Extensions.MJS, StringComparison.InvariantCultureIgnoreCase);
+        }
+
+        public bool IsMJS(string fileName)
+        {
+            if (fileName == null)
+            {
+                return false;
+            }
+
+            return fileName.EndsWith(Files.Extensions.MJS, StringComparison.InvariantCultureIgnoreCase);
         }
 
         public bool IsMinJS(string fileName)

--- a/H5/H5.Placeholders/Attributes/ModuleAttribute.cs
+++ b/H5/H5.Placeholders/Attributes/ModuleAttribute.cs
@@ -49,11 +49,15 @@ namespace H5
         }
     }
 
+    /// <summary>
+    /// Retained for source compatibility with the historical <c>[Module]</c> attribute.
+    /// The packaging of generated JavaScript is now driven by <c>OutputModuleType</c> in
+    /// <c>h5.json</c> (either the default <c>H5.define</c> output or modern ES modules
+    /// emitted as <c>.mjs</c>), so <c>[Module]</c> only carries naming information.
+    /// </summary>
     public enum ModuleType
     {
-        AMD,
-        CommonJS,
-        UMD,
-        ES6
+        /// <summary>Default / unspecified.</summary>
+        ESM = 0,
     }
 }

--- a/H5/H5/Attributes/ModuleAttribute.cs
+++ b/H5/H5/Attributes/ModuleAttribute.cs
@@ -52,12 +52,16 @@ namespace H5
         }
     }
 
+    /// <summary>
+    /// Retained for source compatibility with the historical <c>[Module]</c> attribute.
+    /// The packaging of generated JavaScript is now driven by <c>OutputModuleType</c> in
+    /// <c>h5.json</c> (either the default <c>H5.define</c> output or modern ES modules
+    /// emitted as <c>.mjs</c>), so <c>[Module]</c> only carries naming information.
+    /// </summary>
     [NonScriptable]
     public enum ModuleType
     {
-        AMD,
-        CommonJS,
-        UMD,
-        ES6
+        /// <summary>Default / unspecified.</summary>
+        ESM = 0,
     }
 }

--- a/Tests/Placeholder.PlaywrightTest/index.html
+++ b/Tests/Placeholder.PlaywrightTest/index.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <title>Placeholder ESM Test</title>
+</head>
+<body>
+    <p>Loading...</p>
+    <script type="module">
+      // The h5 runtime, generated assemblies and per-file reflection metadata are
+      // all loaded as ES modules from the h5 output directory. The runtime shim
+      // (h5.mjs) re-exports the global H5 binding so downstream `.mjs` files can
+      // `import { H5 } from "./h5.mjs"`.
+      import { H5 } from "./h5.mjs";
+      await import("./PlaceholderLib.mjs");
+      await import("./app.mjs");
+      await import("./app.meta.mjs");
+
+      // The H5 runtime invokes Main() of every class flagged as an entry point
+      // (via $entryPoint metadata) once H5.init() is ready, so nothing else needs
+      // to run from here.
+      H5.init();
+    </script>
+</body>
+</html>

--- a/Tests/Placeholder.PlaywrightTest/package-lock.json
+++ b/Tests/Placeholder.PlaywrightTest/package-lock.json
@@ -1,0 +1,45 @@
+{
+  "name": "placeholder-esm-test",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "placeholder-esm-test",
+      "version": "1.0.0",
+      "devDependencies": {
+        "playwright": "^1.52.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.52.0.tgz",
+      "integrity": "sha512-JAwMNMBlxJ2oD1kce4KPtMkDeKGHQstdpFPcPH3maElAXon/QZeTvtsfXmTMRyO9TslfoYOXkSsvao2nE1ilTw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.52.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.52.0.tgz",
+      "integrity": "sha512-l2osTgLXSMeuLZOML9qYODUQoPPnUsKsb5/P6LJ2e6uPKXUdPK5WYhN4z03G+YNbWmGDY4YENauNu4ZKczreHg==",
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/Tests/Placeholder.PlaywrightTest/package.json
+++ b/Tests/Placeholder.PlaywrightTest/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "placeholder-esm-test",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Playwright validation harness for h5's ESM output mode (Tests/Placeholder).",
+  "type": "module",
+  "scripts": {
+    "test": "node test-esm.mjs"
+  },
+  "devDependencies": {
+    "playwright": "^1.52.0"
+  }
+}

--- a/Tests/Placeholder.PlaywrightTest/test-esm.mjs
+++ b/Tests/Placeholder.PlaywrightTest/test-esm.mjs
@@ -1,0 +1,158 @@
+// End-to-end validation of h5's ESM output mode.
+//
+// This script:
+//   1. Builds Tests/Placeholder (which uses h5.json `outputModuleType: "ESM"`).
+//   2. Serves the generated .mjs / .js files plus the local test index.html via
+//      a tiny http server.
+//   3. Drives Chromium through Playwright, lets the app execute, then verifies
+//      the globals the app wrote to `window` and the resulting DOM.
+//
+// Usage:
+//   node test-esm.mjs
+
+import { chromium } from "playwright";
+import { spawnSync } from "node:child_process";
+import http from "node:http";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const placeholderProject = path.resolve(__dirname, "..", "Placeholder", "Placeholder.csproj");
+const buildOutput = path.resolve(__dirname, "..", "Placeholder", "bin", "Debug", "netstandard2.0", "h5");
+
+if (process.env.SKIP_BUILD !== "1") {
+    console.log("Building", placeholderProject);
+    const build = spawnSync("dotnet", ["build", placeholderProject, "--nologo", "-v:minimal"], { stdio: "inherit" });
+    if (build.status !== 0) {
+        console.error("dotnet build failed");
+        process.exit(build.status || 1);
+    }
+}
+
+try {
+    await fs.access(buildOutput);
+} catch {
+    console.error("Build output directory missing:", buildOutput);
+    process.exit(1);
+}
+
+const mime = {
+    ".html": "text/html; charset=utf-8",
+    ".mjs":  "text/javascript; charset=utf-8",
+    ".js":   "text/javascript; charset=utf-8",
+    ".css":  "text/css; charset=utf-8",
+    ".json": "application/json; charset=utf-8",
+};
+
+const server = http.createServer(async (req, res) => {
+    const reqPath = decodeURIComponent(new URL(req.url, "http://localhost").pathname);
+
+    if (reqPath === "/favicon.ico") {
+        res.writeHead(204);
+        res.end();
+        return;
+    }
+
+    // /index.html is served from this directory; everything else is served from
+    // the h5 build output directory.
+    const localFile = reqPath === "/" || reqPath === "/index.html" ? "/index.html" : null;
+    const filePath = localFile
+        ? path.join(__dirname, localFile)
+        : path.join(buildOutput, reqPath);
+
+    try {
+        const data = await fs.readFile(filePath);
+        const ext = path.extname(filePath).toLowerCase();
+        res.writeHead(200, { "content-type": mime[ext] || "application/octet-stream" });
+        res.end(data);
+    } catch {
+        res.writeHead(404, { "content-type": "text/plain" });
+        res.end("Not found: " + req.url);
+    }
+});
+
+await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+const { port } = server.address();
+const url = `http://127.0.0.1:${port}/index.html`;
+console.log("Serving from", buildOutput);
+console.log("URL:        ", url);
+
+const browser = await chromium.launch({
+    executablePath: process.env.CHROMIUM_BIN || "/opt/pw-browsers/chromium-1194/chrome-linux/chrome",
+    args: ["--no-sandbox"],
+});
+const context = await browser.newContext();
+const page = await context.newPage();
+
+const consoleMessages = [];
+page.on("console",   (msg)  => consoleMessages.push(`[${msg.type()}] ${msg.text()}`));
+page.on("pageerror", (err) => consoleMessages.push(`[error] ${err.message}`));
+
+const networkErrors = [];
+page.on("response", (response) => {
+    if (response.status() >= 400) {
+        networkErrors.push(`${response.status()} ${response.url()}`);
+    }
+});
+
+await page.goto(url, { waitUntil: "networkidle" });
+
+const result = await page.evaluate(() => ({
+    greeting: window.__h5_test_greeting,
+    sum:      window.__h5_test_sum,
+    message:  window.__h5_test_message,
+    bodyHtml: document.body.innerHTML,
+    helloEl:  document.getElementById("hello") ? document.getElementById("hello").textContent : null,
+}));
+
+// Confirm the generated app.mjs really uses ES module syntax instead of legacy
+// h5.define globals.
+const appMjs = await fs.readFile(path.join(buildOutput, "app.mjs"), "utf8");
+const placeholderLibMjs = await fs.readFile(path.join(buildOutput, "PlaceholderLib.mjs"), "utf8");
+const h5Mjs = await fs.readFile(path.join(buildOutput, "h5.mjs"), "utf8");
+
+console.log("\n=== Page evaluation ===");
+console.log(JSON.stringify(result, null, 2));
+
+console.log("\n=== Console messages ===");
+for (const m of consoleMessages) console.log("  " + m);
+
+if (networkErrors.length > 0) {
+    console.log("\n=== Network errors ===");
+    for (const e of networkErrors) console.log("  " + e);
+}
+
+await browser.close();
+server.close();
+
+let failed = false;
+function expect(label, condition) {
+    if (!condition) {
+        console.error("FAIL:", label);
+        failed = true;
+    } else {
+        console.log("OK  :", label);
+    }
+}
+
+console.log("\n=== Assertions: runtime behaviour ===");
+expect("greeting equals 'Hello, h5!'",  result.greeting === "Hello, h5!");
+expect("sum equals '42'",               result.sum === "42");
+expect("message contains '(42)'",       (result.message || "").includes("(42)"));
+expect("hello element rendered",        (result.helloEl || "").includes("Hello, h5!"));
+expect("no console errors",             !consoleMessages.some(m => m.startsWith("[error]")));
+expect("no network errors",             networkErrors.length === 0);
+
+console.log("\n=== Assertions: generated ESM shape ===");
+expect("app.mjs imports H5 from ./h5.mjs", appMjs.includes(`import { H5 } from "./h5.mjs"`));
+expect("app.mjs exports H5",               appMjs.includes(`export { H5 }`));
+expect("PlaceholderLib.mjs imports H5",    placeholderLibMjs.includes(`import { H5 } from "./h5.mjs"`));
+expect("PlaceholderLib.mjs exports H5",    placeholderLibMjs.includes(`export { H5 }`));
+expect("h5.mjs re-exports global H5",      h5Mjs.includes(`globalThis.H5`) && h5Mjs.includes(`export { H5 }`));
+
+if (failed) {
+    console.error("\nTest FAILED");
+    process.exit(1);
+}
+console.log("\nTest PASSED");

--- a/Tests/Placeholder/App.cs
+++ b/Tests/Placeholder/App.cs
@@ -1,5 +1,6 @@
-﻿using System;
+using System;
 using H5;
+using PlaceholderLib;
 using static H5.Core.dom;
 
 namespace Placeholder
@@ -8,37 +9,18 @@ namespace Placeholder
     {
         private static void Main()
         {
-            if (true)
-            {
-                void Test() { }
+            var greeting = Greeter.Greet("h5");
+            var sum = Greeter.Add(40, 2);
+            var sumString = sum.ToString();
+            var message = greeting + " (" + sumString + ")";
 
-                if (true)
-                {
-                    void Test1() { }
-                    Test1();
+            document.body.innerHTML = "<h1 id=\"hello\">" + message + "</h1>";
 
-                    if (true)
-                    {
-                        void Test2() { }
-                        Test2();
-                        if (true)
-                        {
-                            void Test3() { }
-                            Test3();
-                            
-                            if (true)
-                            {
-                                void Test4() { }
-                                Test4();
-                            }
-                        }
-                    }
-                }
-            }
-            //var hello = "Hello";
-            //var world = World();
-            //document.body.innerHTML = $"{hello} {world}!";
-            //string World() => "World";
+            // Stash strings under window for Playwright to read back without
+            // dealing with how H5 boxes value types into JS objects.
+            window["__h5_test_greeting"] = greeting;
+            window["__h5_test_sum"]      = sumString;
+            window["__h5_test_message"]  = message;
         }
     }
 }

--- a/Tests/Placeholder/h5.json
+++ b/Tests/Placeholder/h5.json
@@ -2,6 +2,13 @@
 {
   "output": "$(OutDir)/h5/",
   "fileName": "app.js",
+
+  // outputModuleType:
+  //   "Default" (or omit)  => historical H5.define output, files end in .js
+  //   "ESM"                => modern ES modules, files end in .mjs and are wrapped in
+  //                           top-level `import { H5 } from "./h5.mjs"; ... export { H5 };`
+  "outputModuleType": "ESM",
+
   "html": {
     "disabled": false,
     "title": "Placeholder"
@@ -16,9 +23,8 @@
     // that builds are more reliable - it's not possible for artifacts from previous builds to exist). A compromise is to use "cleanOutputFolderBeforeBuildPattern": "*.js|*.css" so we can
     // let VS copy in other asset types, such as images, instead of us having to include EVERY additional image and other file in the resources list here).
   ],
-  "cleanOutputFolderBeforeBuildPattern": "*.js|*.css|*.dontload", // See warning above about not using "cleanOutputFolderBeforeBuildPattern": "*.*"
+  "cleanOutputFolderBeforeBuildPattern": "*.js|*.mjs|*.css|*.dontload", // See warning above about not using "cleanOutputFolderBeforeBuildPattern": "*.*". The .mjs entry covers ESM output.
   "console": { "enabled": false },
-  "loader": { "type": "Global" },
   "sourceMap": { "enabled": true },
   "reflection": { "disabled": false },
   "generateTypeScript": false,

--- a/Tests/PlaceholderLib/Greeter.cs
+++ b/Tests/PlaceholderLib/Greeter.cs
@@ -1,0 +1,26 @@
+using System;
+
+namespace PlaceholderLib
+{
+    /// <summary>
+    /// Trivial library type used by Tests/Placeholder to validate that ESM output
+    /// produced by the h5 compiler links across multiple assemblies / generated files.
+    /// </summary>
+    public static class Greeter
+    {
+        public static string Greet(string name)
+        {
+            if (string.IsNullOrEmpty(name))
+            {
+                return "Hello, world!";
+            }
+
+            return "Hello, " + name + "!";
+        }
+
+        public static int Add(int a, int b)
+        {
+            return a + b;
+        }
+    }
+}

--- a/Tests/PlaceholderLib/PlaceholderLib.csproj
+++ b/Tests/PlaceholderLib/PlaceholderLib.csproj
@@ -2,13 +2,14 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
     <DefineConstants>H5</DefineConstants>
-    <AssemblyName>Placeholder</AssemblyName>
-    <AssemblyVersion>123.456.789</AssemblyVersion>
-    <RootNamespace>Placeholder</RootNamespace>
+    <AssemblyName>PlaceholderLib</AssemblyName>
+    <AssemblyVersion>1.0.0.0</AssemblyVersion>
+    <RootNamespace>PlaceholderLib</RootNamespace>
     <LangVersion>7.2</LangVersion>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <DebugType>None</DebugType>
     <DebugSymbols>false</DebugSymbols>
+    <SkipHtmlGeneration>true</SkipHtmlGeneration>
     <UpdateH5>false</UpdateH5>
     <SkipOnlineCheck>true</SkipOnlineCheck>
   </PropertyGroup>
@@ -16,10 +17,5 @@
   <ItemGroup>
     <PackageReference Include="h5" Version="26.2.64514" />
     <PackageReference Include="h5.core" Version="26.2.64455" />
-    <PackageReference Include="h5.Newtonsoft.Json" Version="26.2.64456" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="..\PlaceholderLib\PlaceholderLib.csproj" />
   </ItemGroup>
 </Project>

--- a/Tests/PlaceholderLib/h5.json
+++ b/Tests/PlaceholderLib/h5.json
@@ -1,0 +1,12 @@
+{
+  "output": "$(OutDir)/h5/",
+  "fileName": "PlaceholderLib.js",
+  "outputModuleType": "ESM",
+  "html": { "disabled": true },
+  "cleanOutputFolderBeforeBuildPattern": "*.js|*.mjs|*.css|*.dontload",
+  "console": { "enabled": false },
+  "sourceMap": { "enabled": false },
+  "reflection": { "disabled": true },
+  "generateTypeScript": false,
+  "report": { "enabled": false }
+}


### PR DESCRIPTION
Replace the historical ModuleType/loader.type matrix (AMD / CommonJS /
UMD / ES6) with a single `outputModuleType` switch in h5.json that
chooses between two outputs:

  - `Default` (existing behavior): every assembly registers itself
    through global `H5.assembly` / `H5.define` calls, files end in
    `.js`.
  - `ESM`: same generated body, but each file is emitted as a modern
    ES module. Files end in `.mjs`, the top of every generated file is
    `import { H5 } from "./h5.mjs"`, and a matching `export { H5 }`
    sits at the bottom so downstream `.mjs` files can pull the runtime
    binding through real ES module syntax. A tiny `h5.mjs` shim is
    emitted alongside the existing `h5.js` runtime to re-export the
    global H5 binding (`import "./h5.js"; export { H5 }`).

Implementation:
  - New `OutputModuleType` enum + `H5DotJson_AssemblySettings`
    property (interface + concrete + JSON converter).
  - `EmitBlock.GetOutputForType` picks `.mjs` vs `.js`, swapping an
    existing `.js` filename to `.mjs` when ESM is requested.
  - `Emitter.Output.OutputNonModule` injects the import header /
    export footer around the assembly call.
  - `Emitter.OutputModule` replaces `WrapToAMD/CommonJS/UMD/ES6` with
    just `WrapToH5Define` and `WrapToESM`.
  - `Translator.Output.ExtractEsmShimsIfNeeded` writes the `h5.mjs`
    and `h5.min.mjs` shims when ESM is selected.
  - The legacy `ModuleType.{AMD, CommonJS, UMD, ES6}` and
    `ModuleLoaderType.{AMD, CommonJS, ES6}` enum members are removed
    (only `ESM` / `Global` remain). Dependent emitter / inspector
    code that branched on those is simplified or deleted.

Validation:
  - Tests/PlaceholderLib (new): trivial library project with a
    Greeter type, consumed by Tests/Placeholder via ProjectReference.
  - Tests/Placeholder/h5.json now opts in to `outputModuleType: ESM`
    and the test app calls Greeter to confirm cross-assembly linking.
  - Tests/Placeholder.PlaywrightTest (new): node + Playwright harness
    that builds the placeholder, serves the generated `.mjs` over a
    local http server and asserts both runtime behaviour (DOM render
    + window globals) and the shape of the generated files (correct
    import { H5 } / export { H5 } / shim contents). All 11
    assertions pass.