### PR TITLE
Wrap unary operator operands in parens when they would re-associate

### DIFF
--- a/H5/Compiler/Translator/Emitter/Blocks/UnaryOperatorBlock.cs
+++ b/H5/Compiler/Translator/Emitter/Blocks/UnaryOperatorBlock.cs
@@ -176,6 +176,8 @@ namespace H5.Translator
 
             Emitter.UnaryOperatorType = op;
 
+            bool operandNeedsParens = OperandNeedsParentheses(unaryOperatorExpression.Expression);
+
             if ((isAccessor) &&
                 (op == UnaryOperatorType.Increment ||
                  op == UnaryOperatorType.Decrement ||
@@ -221,7 +223,9 @@ namespace H5.Translator
                         else
                         {
                             Write("~");
+                            if (operandNeedsParens) WriteOpenParentheses();
                             unaryOperatorExpression.Expression.AcceptVisitor(Emitter);
+                            if (operandNeedsParens) WriteCloseParentheses();
                         }
                         break;
 
@@ -271,7 +275,9 @@ namespace H5.Translator
                         else
                         {
                             Write("-");
+                            if (operandNeedsParens) WriteOpenParentheses();
                             unaryOperatorExpression.Expression.AcceptVisitor(Emitter);
+                            if (operandNeedsParens) WriteCloseParentheses();
                         }
                         break;
 
@@ -285,7 +291,9 @@ namespace H5.Translator
                         else
                         {
                             Write("!");
+                            if (operandNeedsParens) WriteOpenParentheses();
                             unaryOperatorExpression.Expression.AcceptVisitor(Emitter);
+                            if (operandNeedsParens) WriteCloseParentheses();
                         }
                         break;
 
@@ -381,6 +389,18 @@ namespace H5.Translator
             }
 
             Emitter.UnaryOperatorType = oldType;
+        }
+
+        private static bool OperandNeedsParentheses(Expression expression)
+        {
+            // JS unary operators bind tighter than these, so without parens the operand would re-associate.
+            return expression is BinaryOperatorExpression
+                || expression is ConditionalExpression
+                || expression is AssignmentExpression
+                || expression is LambdaExpression
+                || expression is AnonymousMethodExpression
+                || expression is IsExpression
+                || expression is AsExpression;
         }
 
         private void AddOveflowFlag(KnownTypeCode typeCode, string op_name, bool lifted)

--- a/Tests/H5.Compiler.IntegrationTests/Language/BasicTests.cs
+++ b/Tests/H5.Compiler.IntegrationTests/Language/BasicTests.cs
@@ -59,5 +59,24 @@ public class Program
 """;
             await RunTest(code);
         }
+
+        [TestMethod]
+        public async Task UnaryNotWrapsBinaryOperand()
+        {
+            var code = """
+using System;
+public class Program
+{
+    public static void Main()
+    {
+        ushort nodeType = 1;
+        if (!(nodeType == 1)) { Console.WriteLine("a"); } else { Console.WriteLine("b"); }
+        nodeType = 3;
+        if (!(nodeType == 1)) { Console.WriteLine("c"); } else { Console.WriteLine("d"); }
+    }
+}
+""";
+            await RunTest(code);
+        }
     }
 }


### PR DESCRIPTION
When the operand of a JS unary operator (!, ~, -) emits a binary,
ternary, assignment, or is/as expression, the unary would otherwise
bind tighter than the inner operator and re-associate. For example,
!(addedNode.nodeType == 1) would emit as `!addedNode.nodeType === 1`
in cases where the AST didn't carry an explicit ParenthesizedExpression.