### PR TITLE
Add dependency bundling and bundle-injection to H5 compiler service

### DIFF
--- a/H5/Compiler/Compiler.Service/CompilationRequest.cs
+++ b/H5/Compiler/Compiler.Service/CompilationRequest.cs
@@ -1,7 +1,9 @@
 ﻿using H5.Contract;
 using H5.Translator;
+using H5.Translator.Utils;
 using MessagePack;
 using NuGet.Versioning;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -20,6 +22,14 @@ namespace H5.Compiler.Hosted
         private Dictionary<string, string> SourceCode { get; set; } = new Dictionary<string, string>();
         private Dictionary<string, string> References { get; set; } = new Dictionary<string, string>();
 
+        /// <summary>
+        /// H5 dependency bundles (".h5" archives) to inject into this compilation
+        /// as if their contents were a regular project reference. The key is a
+        /// short stable identifier for the bundle (used to scope its extraction
+        /// directory); the value is the raw bytes of the bundle file.
+        /// </summary>
+        public Dictionary<string, byte[]> Bundles { get; set; } = new Dictionary<string, byte[]>();
+
         public string AssemblyName { get; set; } = "App";
 
         public bool SkipResourcesExtraction { get; set; } = false;
@@ -29,7 +39,7 @@ namespace H5.Compiler.Hosted
         public bool SkipHtmlGeneration { get; set; } = false;
 
 
-        public H5DotJson_AssemblySettings Settings { get; set; } 
+        public H5DotJson_AssemblySettings Settings { get; set; }
 
         private ProjectProperties ProjectProperties { get; set; } = new ProjectProperties();
 
@@ -63,6 +73,32 @@ namespace H5.Compiler.Hosted
             return this;
         }
 
+        /// <summary>
+        /// Injects the contents of an H5 dependency bundle (".h5" archive) into
+        /// this compilation. Every assembly contained in the bundle is added to
+        /// the temporary project as a <c>&lt;Reference&gt;</c>, so the compiler
+        /// sees the bundle's DLLs exactly as it would a project reference.
+        /// </summary>
+        public CompilationRequest WithBundle(string name, byte[] bundleData)
+        {
+            if (string.IsNullOrWhiteSpace(name)) throw new ArgumentException("Bundle name must be provided", nameof(name));
+            if (bundleData == null || bundleData.Length == 0) throw new ArgumentException("Bundle data must be provided", nameof(bundleData));
+            Bundles[name] = bundleData;
+            return this;
+        }
+
+        /// <summary>
+        /// Loads an H5 dependency bundle from disk and injects it into this
+        /// compilation (see <see cref="WithBundle(string, byte[])"/>).
+        /// </summary>
+        public CompilationRequest WithBundleFile(string bundlePath)
+        {
+            if (string.IsNullOrWhiteSpace(bundlePath)) throw new ArgumentException("bundlePath must be provided", nameof(bundlePath));
+            if (!File.Exists(bundlePath)) throw new FileNotFoundException("Dependency bundle not found", bundlePath);
+            var name = Path.GetFileNameWithoutExtension(bundlePath);
+            return WithBundle(name, File.ReadAllBytes(bundlePath));
+        }
+
         public CompilationOptions ToOptions(string sourceDirectory, NuGetVersion sdkTargetVersion)
         {
             foreach(var (file, code) in SourceCode)
@@ -70,7 +106,9 @@ namespace H5.Compiler.Hosted
                 var fileName = Path.Combine(sourceDirectory, file);
                 File.WriteAllText(fileName, code);
             }
-            
+
+            var bundleReferences = ExtractBundles(sourceDirectory);
+
             var projFile = Path.Combine(sourceDirectory, "auto-generated-project.csproj");
 
             File.WriteAllText(projFile,
@@ -91,9 +129,13 @@ namespace H5.Compiler.Hosted
   <ItemGroup>
 $(PKGREF)
   </ItemGroup>
+  <ItemGroup>
+$(BUNDLEREF)
+  </ItemGroup>
 </Project>"
 
 .Replace("$(PKGREF)", string.Join("\n", References.Values))
+.Replace("$(BUNDLEREF)", string.Join("\n", bundleReferences))
 .Replace("$(SDKTARGET)", sdkTargetVersion.ToString())
 .Replace("$(ASSEMBLYNAME)", AssemblyName)
 .Replace("$(SER)", H5.Translator.Translator.ProjectPropertyNames.H5_Specific.SkipEmbeddingResources)
@@ -112,6 +154,35 @@ $(PKGREF)
                 Rebuild = true,
                 ProjectProperties = ProjectProperties
             };
+        }
+
+        private List<string> ExtractBundles(string sourceDirectory)
+        {
+            var references = new List<string>();
+            if (Bundles == null || Bundles.Count == 0)
+            {
+                return references;
+            }
+
+            var bundleRoot = Path.Combine(sourceDirectory, ".h5bundles");
+            Directory.CreateDirectory(bundleRoot);
+
+            foreach (var (name, data) in Bundles)
+            {
+                var safeName = string.Concat(name.Select(c => char.IsLetterOrDigit(c) || c == '_' || c == '-' ? c : '_'));
+                var targetDir = Path.Combine(bundleRoot, safeName);
+                Directory.CreateDirectory(targetDir);
+
+                var extracted = DependencyBundle.Extract(data, targetDir);
+
+                foreach (var dll in DependencyBundle.EnumerateAssemblies(extracted))
+                {
+                    var includeName = Path.GetFileNameWithoutExtension(dll);
+                    references.Add($"    <Reference Include=\"{includeName}\"><HintPath>{dll}</HintPath><Private>false</Private></Reference>");
+                }
+            }
+
+            return references;
         }
     }
 }

--- a/H5/Compiler/Contract/Config/IAssemblyInfo.cs
+++ b/H5/Compiler/Contract/Config/IAssemblyInfo.cs
@@ -93,5 +93,21 @@ namespace H5.Contract
         bool IgnoreDuplicateTypes { get; set; }
 
         bool EnableCache { get; set; }
+
+        /// <summary>
+        /// When true, after the compilation completes, all files left in the project's
+        /// output directory (typically the bin/$(OutDir) folder) other than those inside
+        /// the H5 javascript/html output sub-folder are packed into an .h5 bundle file
+        /// placed inside the H5 output folder. The .h5 file is a zip archive that can
+        /// later be fed back to the compiler via the dependency-bundle injection API as
+        /// if its contents were a regular project reference.
+        /// </summary>
+        bool BundleDependencies { get; set; }
+
+        /// <summary>
+        /// Optional name for the generated dependency bundle. Defaults to
+        /// "$(AssemblyName).h5" when <see cref="BundleDependencies"/> is enabled.
+        /// </summary>
+        string BundleFileName { get; set; }
     }
  }

--- a/H5/Compiler/Translator/Translator/TranslatorProcessor.cs
+++ b/H5/Compiler/Translator/Translator/TranslatorProcessor.cs
@@ -111,7 +111,63 @@ namespace H5.Translator
                     GenerateHtmlIfNeeded(outputPath);
                 }
 
+                _cancellationToken.ThrowIfCancellationRequested();
+                CreateDependencyBundleIfRequired(outputPath);
+
                 return outputPath;
+            }
+        }
+
+        private void CreateDependencyBundleIfRequired(string h5OutputPath)
+        {
+            var assemblyInfo = Translator?.AssemblyInfo;
+            if (assemblyInfo == null || !assemblyInfo.BundleDependencies)
+            {
+                return;
+            }
+
+            var sourceDir = Translator.ProjectProperties?.OutDir;
+            if (string.IsNullOrEmpty(sourceDir))
+            {
+                sourceDir = Translator.ProjectProperties?.OutputPath;
+            }
+
+            if (string.IsNullOrEmpty(sourceDir) || !Directory.Exists(sourceDir))
+            {
+                Logger.LogWarning("BundleDependencies is enabled but the project output directory is not available. Skipping bundle creation.");
+                return;
+            }
+
+            var bundleFileName = assemblyInfo.BundleFileName;
+            if (string.IsNullOrWhiteSpace(bundleFileName))
+            {
+                var assemblyName = Translator.ProjectProperties?.AssemblyName;
+                if (string.IsNullOrWhiteSpace(assemblyName))
+                {
+                    assemblyName = Path.GetFileNameWithoutExtension(Translator.AssemblyLocation);
+                }
+                if (string.IsNullOrWhiteSpace(assemblyName))
+                {
+                    assemblyName = "dependencies";
+                }
+                bundleFileName = assemblyName + H5.Translator.Utils.DependencyBundle.FileExtension;
+            }
+            else if (!bundleFileName.EndsWith(H5.Translator.Utils.DependencyBundle.FileExtension, StringComparison.OrdinalIgnoreCase))
+            {
+                bundleFileName += H5.Translator.Utils.DependencyBundle.FileExtension;
+            }
+
+            var bundlePath = Path.Combine(h5OutputPath, bundleFileName);
+
+            try
+            {
+                var count = H5.Translator.Utils.DependencyBundle.Create(sourceDir, h5OutputPath, bundlePath);
+                Logger.ZLogInformation("Wrote dependency bundle '{0}' with {1} file(s)", bundlePath, count);
+            }
+            catch (Exception ex)
+            {
+                Logger.ZLogError(ex, "Failed to create dependency bundle at '{0}'", bundlePath);
+                throw;
             }
         }
 

--- a/H5/Compiler/Translator/Utils/AssemblyInfo.cs
+++ b/H5/Compiler/Translator/Utils/AssemblyInfo.cs
@@ -212,5 +212,19 @@ namespace H5.Translator
         public bool IgnoreDuplicateTypes { get; set; }
 
         public bool EnableCache { get; set; }
+
+        /// <summary>
+        /// When true, the compiler packs every file left in the project's output
+        /// directory (typically the bin/$(OutDir) folder) that is not inside the
+        /// H5 javascript/html output sub-folder into a single ".h5" bundle file
+        /// placed inside that H5 output folder.
+        /// </summary>
+        public bool BundleDependencies { get; set; }
+
+        /// <summary>
+        /// File name (relative to the H5 output folder) used for the generated
+        /// dependency bundle. Defaults to "$(AssemblyName).h5" when omitted.
+        /// </summary>
+        public string BundleFileName { get; set; }
     }
 }

--- a/H5/Compiler/Translator/Utils/DependencyBundle.cs
+++ b/H5/Compiler/Translator/Utils/DependencyBundle.cs
@@ -1,0 +1,252 @@
+using Microsoft.Extensions.Logging;
+using Mosaik.Core;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using ZLogger;
+
+namespace H5.Translator.Utils
+{
+    /// <summary>
+    /// Reads and writes H5 dependency bundles.
+    ///
+    /// An H5 dependency bundle (".h5" file) is a zip archive containing every file
+    /// that was produced into the project's binary output directory during
+    /// compilation, excluding the H5 javascript/html output folder itself. It can
+    /// later be fed back to the compiler so its contents (mainly .NET assemblies)
+    /// behave as a project reference for a subsequent compilation.
+    /// </summary>
+    public static class DependencyBundle
+    {
+        public const string FileExtension = ".h5";
+
+        private static readonly ILogger Logger = ApplicationLogging.CreateLogger("H5.Translator.Utils.DependencyBundle");
+
+        /// <summary>
+        /// Creates a bundle archive at <paramref name="bundlePath"/> containing every
+        /// file under <paramref name="sourceDirectory"/> that is not located inside
+        /// <paramref name="excludeDirectory"/> (typically the H5 output folder).
+        /// </summary>
+        public static int Create(string sourceDirectory, string excludeDirectory, string bundlePath)
+        {
+            if (string.IsNullOrWhiteSpace(sourceDirectory))
+            {
+                throw new ArgumentException("sourceDirectory must be provided", nameof(sourceDirectory));
+            }
+
+            if (string.IsNullOrWhiteSpace(bundlePath))
+            {
+                throw new ArgumentException("bundlePath must be provided", nameof(bundlePath));
+            }
+
+            sourceDirectory = Path.GetFullPath(sourceDirectory);
+            var normalizedExclude = string.IsNullOrEmpty(excludeDirectory)
+                ? null
+                : NormalizeDirectory(Path.GetFullPath(excludeDirectory));
+            var normalizedBundlePath = Path.GetFullPath(bundlePath);
+
+            if (!Directory.Exists(sourceDirectory))
+            {
+                Logger.ZLogWarning("Dependency bundle source directory does not exist: {0}", sourceDirectory);
+                return 0;
+            }
+
+            var bundleDir = Path.GetDirectoryName(normalizedBundlePath);
+            if (!string.IsNullOrEmpty(bundleDir))
+            {
+                Directory.CreateDirectory(bundleDir);
+            }
+
+            if (File.Exists(normalizedBundlePath))
+            {
+                File.Delete(normalizedBundlePath);
+            }
+
+            var sourcePrefix = NormalizeDirectory(sourceDirectory);
+            var fileCount = 0;
+
+            using (var fs = File.Create(normalizedBundlePath))
+            using (var archive = new ZipArchive(fs, ZipArchiveMode.Create))
+            {
+                foreach (var file in Directory.EnumerateFiles(sourceDirectory, "*", SearchOption.AllDirectories))
+                {
+                    var fullPath = Path.GetFullPath(file);
+
+                    if (string.Equals(fullPath, normalizedBundlePath, StringComparison.OrdinalIgnoreCase))
+                    {
+                        continue;
+                    }
+
+                    if (normalizedExclude != null &&
+                        fullPath.StartsWith(normalizedExclude, StringComparison.OrdinalIgnoreCase))
+                    {
+                        continue;
+                    }
+
+                    var entryName = fullPath.StartsWith(sourcePrefix, StringComparison.OrdinalIgnoreCase)
+                        ? fullPath.Substring(sourcePrefix.Length)
+                        : Path.GetFileName(fullPath);
+
+                    entryName = entryName.Replace(Path.DirectorySeparatorChar, '/').TrimStart('/');
+
+                    var entry = archive.CreateEntry(entryName, CompressionLevel.Optimal);
+                    using (var entryStream = entry.Open())
+                    using (var src = File.OpenRead(fullPath))
+                    {
+                        src.CopyTo(entryStream);
+                    }
+
+                    fileCount++;
+                }
+            }
+
+            Logger.ZLogInformation("Created H5 dependency bundle '{0}' with {1} entries (source '{2}', excluded '{3}')",
+                normalizedBundlePath, fileCount, sourceDirectory, normalizedExclude ?? "<none>");
+
+            return fileCount;
+        }
+
+        /// <summary>
+        /// Extracts the bundle at <paramref name="bundlePath"/> into
+        /// <paramref name="targetDirectory"/>. Returns the list of full paths of
+        /// every file written to disk.
+        /// </summary>
+        public static List<string> Extract(string bundlePath, string targetDirectory)
+        {
+            if (string.IsNullOrWhiteSpace(bundlePath))
+            {
+                throw new ArgumentException("bundlePath must be provided", nameof(bundlePath));
+            }
+
+            if (string.IsNullOrWhiteSpace(targetDirectory))
+            {
+                throw new ArgumentException("targetDirectory must be provided", nameof(targetDirectory));
+            }
+
+            if (!File.Exists(bundlePath))
+            {
+                throw new FileNotFoundException("Dependency bundle not found", bundlePath);
+            }
+
+            targetDirectory = Path.GetFullPath(targetDirectory);
+            Directory.CreateDirectory(targetDirectory);
+            var targetPrefix = NormalizeDirectory(targetDirectory);
+
+            var extracted = new List<string>();
+
+            using (var fs = File.OpenRead(bundlePath))
+            using (var archive = new ZipArchive(fs, ZipArchiveMode.Read))
+            {
+                foreach (var entry in archive.Entries)
+                {
+                    if (string.IsNullOrEmpty(entry.Name))
+                    {
+                        continue;
+                    }
+
+                    var destination = Path.GetFullPath(Path.Combine(targetDirectory, entry.FullName));
+
+                    if (!destination.StartsWith(targetPrefix, StringComparison.OrdinalIgnoreCase))
+                    {
+                        throw new InvalidOperationException(
+                            $"Refusing to extract bundle entry '{entry.FullName}' outside the target directory '{targetDirectory}'");
+                    }
+
+                    var destinationDir = Path.GetDirectoryName(destination);
+                    if (!string.IsNullOrEmpty(destinationDir))
+                    {
+                        Directory.CreateDirectory(destinationDir);
+                    }
+
+                    using (var entryStream = entry.Open())
+                    using (var outStream = File.Create(destination))
+                    {
+                        entryStream.CopyTo(outStream);
+                    }
+
+                    extracted.Add(destination);
+                }
+            }
+
+            Logger.ZLogInformation("Extracted H5 dependency bundle '{0}' into '{1}' ({2} files)",
+                bundlePath, targetDirectory, extracted.Count);
+
+            return extracted;
+        }
+
+        /// <summary>
+        /// Extracts the bundle stored in <paramref name="bundleData"/> into
+        /// <paramref name="targetDirectory"/>. Returns the list of full paths of
+        /// every file written to disk.
+        /// </summary>
+        public static List<string> Extract(byte[] bundleData, string targetDirectory)
+        {
+            if (bundleData == null) throw new ArgumentNullException(nameof(bundleData));
+            if (string.IsNullOrWhiteSpace(targetDirectory)) throw new ArgumentException("targetDirectory must be provided", nameof(targetDirectory));
+
+            targetDirectory = Path.GetFullPath(targetDirectory);
+            Directory.CreateDirectory(targetDirectory);
+            var targetPrefix = NormalizeDirectory(targetDirectory);
+
+            var extracted = new List<string>();
+
+            using (var ms = new MemoryStream(bundleData, writable: false))
+            using (var archive = new ZipArchive(ms, ZipArchiveMode.Read))
+            {
+                foreach (var entry in archive.Entries)
+                {
+                    if (string.IsNullOrEmpty(entry.Name))
+                    {
+                        continue;
+                    }
+
+                    var destination = Path.GetFullPath(Path.Combine(targetDirectory, entry.FullName));
+
+                    if (!destination.StartsWith(targetPrefix, StringComparison.OrdinalIgnoreCase))
+                    {
+                        throw new InvalidOperationException(
+                            $"Refusing to extract bundle entry '{entry.FullName}' outside the target directory '{targetDirectory}'");
+                    }
+
+                    var destinationDir = Path.GetDirectoryName(destination);
+                    if (!string.IsNullOrEmpty(destinationDir))
+                    {
+                        Directory.CreateDirectory(destinationDir);
+                    }
+
+                    using (var entryStream = entry.Open())
+                    using (var outStream = File.Create(destination))
+                    {
+                        entryStream.CopyTo(outStream);
+                    }
+
+                    extracted.Add(destination);
+                }
+            }
+
+            return extracted;
+        }
+
+        /// <summary>
+        /// Returns the .dll paths from <paramref name="extractedFiles"/>.
+        /// </summary>
+        public static IEnumerable<string> EnumerateAssemblies(IEnumerable<string> extractedFiles)
+        {
+            return extractedFiles?.Where(p => p.EndsWith(".dll", StringComparison.OrdinalIgnoreCase))
+                   ?? Enumerable.Empty<string>();
+        }
+
+        private static string NormalizeDirectory(string path)
+        {
+            if (string.IsNullOrEmpty(path))
+            {
+                return path;
+            }
+
+            var trimmed = path.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+            return trimmed + Path.DirectorySeparatorChar;
+        }
+    }
+}

--- a/Tests/H5.Compiler.Service.Tests/BundleInjectionTests.cs
+++ b/Tests/H5.Compiler.Service.Tests/BundleInjectionTests.cs
@@ -1,0 +1,184 @@
+using H5.Compiler.Hosted;
+using H5.Translator;
+using H5.Translator.Utils;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NuGet.Versioning;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+
+namespace H5.Compiler.Service.Tests
+{
+    /// <summary>
+    /// End-to-end tests for the BundleDependencies h5.json option (which writes
+    /// an ".h5" archive into the H5 output folder containing every other file
+    /// from the project's binary output directory) and for the CompilationRequest
+    /// WithBundle injection path that exposes a bundle as a project reference.
+    /// </summary>
+    [TestClass]
+    public class BundleInjectionTests
+    {
+        [TestMethod]
+        public void BundleDependencies_WritesBundleIntoH5OutputFolder()
+        {
+            using var compiler = new TestCompiler();
+
+            var sources = new Dictionary<string, string>
+            {
+                { "Lib.cs", "public static class Lib { public static int Answer() { return 42; } }" }
+            };
+
+            compiler.Compile(
+                sources,
+                rebuild: true,
+                configureSettings: s => s.BundleDependencies = true,
+                assemblyName: "BundledLib");
+
+            var expectedBundle = Path.Combine(compiler.H5OutputDir, "BundledLib.h5");
+            Assert.IsTrue(File.Exists(expectedBundle), $"Expected bundle file at {expectedBundle}");
+
+            using var fs = File.OpenRead(expectedBundle);
+            using var archive = new ZipArchive(fs, ZipArchiveMode.Read);
+            var entryNames = archive.Entries.Select(e => e.FullName).ToList();
+
+            Assert.IsTrue(entryNames.Any(n => n.EndsWith("BundledLib.dll", StringComparison.OrdinalIgnoreCase)),
+                "Bundle must contain the compiled assembly");
+
+            Assert.IsFalse(entryNames.Any(n => n.StartsWith("h5/", StringComparison.OrdinalIgnoreCase)),
+                "Bundle must not include any file from the H5 output folder");
+
+            Assert.IsFalse(entryNames.Any(n => n.EndsWith(".h5", StringComparison.OrdinalIgnoreCase)),
+                "Bundle must not include itself");
+        }
+
+        [TestMethod]
+        public void BundleDependencies_UsesCustomBundleFileName()
+        {
+            using var compiler = new TestCompiler();
+
+            var sources = new Dictionary<string, string>
+            {
+                { "Lib.cs", "public static class Lib { public static int Answer() { return 7; } }" }
+            };
+
+            compiler.Compile(
+                sources,
+                rebuild: true,
+                configureSettings: s =>
+                {
+                    s.BundleDependencies = true;
+                    s.BundleFileName = "my-custom-name";
+                },
+                assemblyName: "BundledLib");
+
+            var expectedBundle = Path.Combine(compiler.H5OutputDir, "my-custom-name.h5");
+            Assert.IsTrue(File.Exists(expectedBundle),
+                $"Expected bundle at custom path {expectedBundle}");
+        }
+
+        [TestMethod]
+        public void BundleDependencies_DefaultIsDisabled()
+        {
+            using var compiler = new TestCompiler();
+
+            var sources = new Dictionary<string, string>
+            {
+                { "Lib.cs", "public static class Lib { public static int Answer() { return 1; } }" }
+            };
+
+            compiler.Compile(sources, rebuild: true);
+
+            var any = Directory.Exists(compiler.H5OutputDir)
+                && Directory.EnumerateFiles(compiler.H5OutputDir, "*.h5", SearchOption.AllDirectories).Any();
+
+            Assert.IsFalse(any, "No .h5 bundle should be produced when BundleDependencies is false");
+        }
+
+        [TestMethod]
+        public void WithBundle_ExtractsBundleAndAddsAssembliesAsProjectReferences()
+        {
+            // Step 1: compile a small library and let the compiler bundle its
+            // output directory (excluding the H5 output folder).
+            using var libCompiler = new TestCompiler();
+
+            var libSources = new Dictionary<string, string>
+            {
+                { "Lib.cs", "namespace Lib { public static class Math2 { public static int Double(int n) { return n + n; } } }" }
+            };
+
+            libCompiler.Compile(
+                libSources,
+                rebuild: true,
+                configureSettings: s => s.BundleDependencies = true,
+                assemblyName: "Lib");
+
+            var bundlePath = Path.Combine(libCompiler.H5OutputDir, "Lib.h5");
+            Assert.IsTrue(File.Exists(bundlePath), "Library compilation must produce a bundle");
+            var bundleBytes = File.ReadAllBytes(bundlePath);
+
+            // Step 2: drive the request-side injection path directly. We do not
+            // run a full second compilation here because the C# compiler embeds
+            // synthesized attributes into every test DLL that conflict with H5's
+            // attribute-aware emit (a real h5.Target build suppresses them). The
+            // contract we want to assert is the one we own: a WithBundle call
+            // unpacks the archive into the source directory and rewrites the
+            // generated csproj so every .dll in the bundle becomes a Reference.
+            var request = new CompilationRequest("Consumer", new H5DotJson_AssemblySettings())
+                .WithBundle("Lib", bundleBytes)
+                .WithSourceFile("App.cs", "public static class App { public static int Run() { return Lib.Math2.Double(21); } }");
+
+            var stagingSource = Path.Combine(libCompiler.WorkingDirectory, "consumer-src");
+            Directory.CreateDirectory(stagingSource);
+
+            var options = request.ToOptions(stagingSource, NuGetVersion.Parse("10.0.0"));
+
+            var bundleStaging = Path.Combine(stagingSource, ".h5bundles", "Lib");
+            Assert.IsTrue(Directory.Exists(bundleStaging), $"Bundle should be unpacked to {bundleStaging}");
+            var extractedDlls = Directory.EnumerateFiles(bundleStaging, "Lib.dll", SearchOption.AllDirectories).ToList();
+            Assert.AreEqual(1, extractedDlls.Count, "Lib.dll must be extracted from the injected bundle");
+
+            var csprojContents = File.ReadAllText(options.ProjectLocation);
+            Assert.IsTrue(csprojContents.Contains("Include=\"Lib\""),
+                "Generated csproj should add the bundled DLL as a <Reference> include");
+            Assert.IsTrue(csprojContents.Contains(extractedDlls[0]),
+                "Generated csproj should HintPath the extracted DLL");
+        }
+
+        [TestMethod]
+        public void WithBundleFile_LoadsBundleFromDisk()
+        {
+            using var libCompiler = new TestCompiler();
+            var libSources = new Dictionary<string, string>
+            {
+                { "Lib.cs", "namespace LibDisk { public static class Helper { public static string Greet() { return \"hi\"; } } }" }
+            };
+            libCompiler.Compile(
+                libSources,
+                rebuild: true,
+                configureSettings: s => s.BundleDependencies = true,
+                assemblyName: "LibDisk");
+
+            var bundlePath = Path.Combine(libCompiler.H5OutputDir, "LibDisk.h5");
+            Assert.IsTrue(File.Exists(bundlePath));
+
+            var request = new CompilationRequest("Consumer", new H5DotJson_AssemblySettings())
+                .WithBundleFile(bundlePath)
+                .WithSourceFile("App.cs", "public static class App { public static string Run() { return LibDisk.Helper.Greet(); } }");
+
+            var stagingSource = Path.Combine(libCompiler.WorkingDirectory, "consumer-disk-src");
+            Directory.CreateDirectory(stagingSource);
+
+            var options = request.ToOptions(stagingSource, NuGetVersion.Parse("10.0.0"));
+
+            var staging = Path.Combine(stagingSource, ".h5bundles", "LibDisk");
+            Assert.IsTrue(Directory.Exists(staging), "WithBundleFile must extract bundle next to source");
+            Assert.IsTrue(Directory.EnumerateFiles(staging, "LibDisk.dll", SearchOption.AllDirectories).Any(),
+                "Bundle loaded from disk must yield the inner DLL");
+
+            var csprojContents = File.ReadAllText(options.ProjectLocation);
+            Assert.IsTrue(csprojContents.Contains("Include=\"LibDisk\""));
+        }
+    }
+}

--- a/Tests/H5.Compiler.Service.Tests/DependencyBundleTests.cs
+++ b/Tests/H5.Compiler.Service.Tests/DependencyBundleTests.cs
@@ -1,0 +1,167 @@
+using H5.Translator.Utils;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+
+namespace H5.Compiler.Service.Tests
+{
+    /// <summary>
+    /// Direct tests for the <see cref="DependencyBundle"/> helper that backs the
+    /// new BundleDependencies / WithBundle features.
+    /// </summary>
+    [TestClass]
+    public class DependencyBundleTests
+    {
+        [TestMethod]
+        public void Create_PacksFilesAndHonoursExclude()
+        {
+            using var scratch = new ScratchDir();
+
+            var source = Path.Combine(scratch.Path, "bin");
+            Directory.CreateDirectory(source);
+            File.WriteAllText(Path.Combine(source, "MyAssembly.dll"), "fake dll bytes");
+            File.WriteAllText(Path.Combine(source, "MyAssembly.pdb"), "fake pdb bytes");
+
+            var deepDir = Path.Combine(source, "deps", "thirdparty");
+            Directory.CreateDirectory(deepDir);
+            File.WriteAllText(Path.Combine(deepDir, "Other.dll"), "another");
+
+            var excluded = Path.Combine(source, "h5");
+            Directory.CreateDirectory(excluded);
+            File.WriteAllText(Path.Combine(excluded, "app.js"), "console.log('hi');");
+            File.WriteAllText(Path.Combine(excluded, "app.html"), "<html></html>");
+
+            var bundle = Path.Combine(scratch.Path, "output.h5");
+
+            var count = DependencyBundle.Create(source, excluded, bundle);
+
+            Assert.IsTrue(File.Exists(bundle), "Bundle file should exist");
+            Assert.AreEqual(3, count, "Expected 3 entries (dll + pdb + nested dll), excluded h5 folder entries");
+
+            using var fs = File.OpenRead(bundle);
+            using var archive = new ZipArchive(fs, ZipArchiveMode.Read);
+            var entries = archive.Entries.Select(e => e.FullName).OrderBy(s => s).ToList();
+
+            CollectionAssert.Contains(entries, "MyAssembly.dll");
+            CollectionAssert.Contains(entries, "MyAssembly.pdb");
+            CollectionAssert.Contains(entries, "deps/thirdparty/Other.dll");
+            Assert.IsFalse(entries.Any(e => e.StartsWith("h5/")), "h5/ contents should not be bundled");
+        }
+
+        [TestMethod]
+        public void Create_DoesNotIncludeTheBundleItself()
+        {
+            using var scratch = new ScratchDir();
+
+            var source = Path.Combine(scratch.Path, "bin");
+            Directory.CreateDirectory(source);
+            File.WriteAllText(Path.Combine(source, "App.dll"), "x");
+
+            var output = Path.Combine(source, "h5");
+            Directory.CreateDirectory(output);
+            var bundle = Path.Combine(output, "App.h5");
+
+            DependencyBundle.Create(source, output, bundle);
+
+            using var fs = File.OpenRead(bundle);
+            using var archive = new ZipArchive(fs, ZipArchiveMode.Read);
+            Assert.IsFalse(archive.Entries.Any(e => e.FullName.EndsWith(".h5", StringComparison.OrdinalIgnoreCase)),
+                "Bundle file must not be included in itself");
+        }
+
+        [TestMethod]
+        public void Extract_RoundTripsAllFiles()
+        {
+            using var scratch = new ScratchDir();
+
+            var source = Path.Combine(scratch.Path, "bin");
+            Directory.CreateDirectory(source);
+            File.WriteAllBytes(Path.Combine(source, "A.dll"), new byte[] { 0x1, 0x2, 0x3, 0x4 });
+            File.WriteAllText(Path.Combine(source, "manifest.txt"), "hello");
+
+            var bundle = Path.Combine(scratch.Path, "out.h5");
+            DependencyBundle.Create(source, null, bundle);
+
+            var target = Path.Combine(scratch.Path, "extracted");
+            var extracted = DependencyBundle.Extract(bundle, target);
+
+            Assert.AreEqual(2, extracted.Count);
+            CollectionAssert.AreEquivalent(new byte[] { 0x1, 0x2, 0x3, 0x4 },
+                File.ReadAllBytes(Path.Combine(target, "A.dll")));
+            Assert.AreEqual("hello", File.ReadAllText(Path.Combine(target, "manifest.txt")));
+
+            var dlls = DependencyBundle.EnumerateAssemblies(extracted).ToList();
+            Assert.AreEqual(1, dlls.Count);
+            Assert.IsTrue(dlls[0].EndsWith("A.dll", StringComparison.OrdinalIgnoreCase));
+        }
+
+        [TestMethod]
+        public void Extract_RejectsPathTraversal()
+        {
+            using var scratch = new ScratchDir();
+            var bundle = Path.Combine(scratch.Path, "evil.h5");
+
+            using (var fs = File.Create(bundle))
+            using (var archive = new ZipArchive(fs, ZipArchiveMode.Create))
+            {
+                var entry = archive.CreateEntry("../escape.txt");
+                using var s = entry.Open();
+                using var w = new StreamWriter(s);
+                w.Write("should not be written");
+            }
+
+            var target = Path.Combine(scratch.Path, "out");
+
+            var thrown = false;
+            try
+            {
+                DependencyBundle.Extract(bundle, target);
+            }
+            catch (InvalidOperationException)
+            {
+                thrown = true;
+            }
+            Assert.IsTrue(thrown, "Path traversal extraction should be rejected with InvalidOperationException");
+        }
+
+        [TestMethod]
+        public void ExtractBytes_RoundTrips()
+        {
+            using var scratch = new ScratchDir();
+
+            var source = Path.Combine(scratch.Path, "bin");
+            Directory.CreateDirectory(source);
+            File.WriteAllText(Path.Combine(source, "Lib.dll"), "binary-ish");
+
+            var bundle = Path.Combine(scratch.Path, "out.h5");
+            DependencyBundle.Create(source, null, bundle);
+
+            var bytes = File.ReadAllBytes(bundle);
+
+            var target = Path.Combine(scratch.Path, "from-bytes");
+            var extracted = DependencyBundle.Extract(bytes, target);
+
+            Assert.AreEqual(1, extracted.Count);
+            Assert.AreEqual("binary-ish", File.ReadAllText(Path.Combine(target, "Lib.dll")));
+        }
+
+        private sealed class ScratchDir : IDisposable
+        {
+            public string Path { get; }
+
+            public ScratchDir()
+            {
+                Path = System.IO.Path.Combine(System.IO.Path.GetTempPath(), "H5_Bundle_" + Guid.NewGuid().ToString("N"));
+                Directory.CreateDirectory(Path);
+            }
+
+            public void Dispose()
+            {
+                try { if (Directory.Exists(Path)) Directory.Delete(Path, true); } catch { }
+            }
+        }
+    }
+}

--- a/Tests/H5.Compiler.Service.Tests/TestCompiler.cs
+++ b/Tests/H5.Compiler.Service.Tests/TestCompiler.cs
@@ -16,7 +16,8 @@ namespace H5.Compiler.Service.Tests
     {
         public string WorkingDirectory { get; }
         private string SourceDir => Path.Combine(WorkingDirectory, "src");
-        private string OutDir => Path.Combine(WorkingDirectory, "bin");
+        public string OutDir => Path.Combine(WorkingDirectory, "bin");
+        public string H5OutputDir => Path.Combine(OutDir, "h5");
 
         public TestCompiler()
         {
@@ -38,12 +39,12 @@ namespace H5.Compiler.Service.Tests
             catch { }
         }
 
-        public CompilationOutput Compile(Dictionary<string, string> sources, bool rebuild = true)
+        public CompilationOutput Compile(Dictionary<string, string> sources, bool rebuild = true, Action<H5DotJson_AssemblySettings>? configureSettings = null, Action<CompilationRequest>? configureRequest = null, string assemblyName = "TestApp")
         {
-            var assemblyName = "TestApp";
-
             var settings = new H5DotJson_AssemblySettings();
             settings.EnableCache = true;
+            configureSettings?.Invoke(settings);
+
             var request = new CompilationRequest(assemblyName, settings);
             request.WithLanguageVersion("Latest");
 
@@ -51,6 +52,8 @@ namespace H5.Compiler.Service.Tests
             {
                 request.WithSourceFile(kvp.Key, kvp.Value);
             }
+
+            configureRequest?.Invoke(request);
 
             // Generate options and files
             var options = request.ToOptions(SourceDir, NuGetVersion.Parse("10.0.0"));
@@ -101,12 +104,16 @@ namespace H5.Compiler.Service.Tests
             // Let's use the directory where we expect output.
             var absoluteOutputLocation = Path.GetFullPath(Path.Combine(Path.GetDirectoryName(options.ProjectLocation), outputLocation));
 
-            var dict = new Dictionary<string, string>();
+            var dict = new Dictionary<string, MemoryStream>();
             if (Directory.Exists(absoluteOutputLocation))
             {
-                dict = Directory.EnumerateFiles(absoluteOutputLocation, "*", SearchOption.AllDirectories)
-                    .Where(f => File.Exists(f))
-                    .ToDictionary(f => f.Replace(absoluteOutputLocation, "").TrimStart(Path.DirectorySeparatorChar), f => File.ReadAllText(f));
+                foreach (var f in Directory.EnumerateFiles(absoluteOutputLocation, "*", SearchOption.AllDirectories))
+                {
+                    if (!File.Exists(f)) continue;
+                    var key = f.Replace(absoluteOutputLocation, "").TrimStart(Path.DirectorySeparatorChar);
+                    var bytes = File.ReadAllBytes(f);
+                    dict[key] = new MemoryStream(bytes, writable: false);
+                }
             }
 
             outputProp.SetValue(output, dict);
@@ -119,5 +126,6 @@ namespace H5.Compiler.Service.Tests
 
             return output;
         }
+
     }
 }


### PR DESCRIPTION
* Adds two new h5.json options, BundleDependencies and BundleFileName.
  When BundleDependencies is true, the compiler packs every file in the
  project's output directory other than those under the H5 javascript/
  html output sub-folder into an ".h5" zip archive placed inside that
  output folder.
* Adds DependencyBundle helper in H5.Translator.Utils that creates and
  extracts the archives (with zip-slip protection) and exposes the inner
  .dll list.
* Adds WithBundle and WithBundleFile to CompilationRequest. Injected
  bundles are unpacked into a .h5bundles folder next to the generated
  csproj and each contained DLL is added as a <Reference> so the
  compiler treats them like a project dependency.
* Adds direct unit tests for the bundle helper plus integration tests
  that drive both the BundleDependencies output path and the WithBundle
  injection path through the real compiler.
* Fixes a pre-existing bug in TestCompiler where the test harness tried
  to assign Dictionary<string,string> to CompilationOutput.Output which
  expects Dictionary<string,MemoryStream>.