### PR TITLE
Fix mutex thread affinity issue in compilation server startup

### DIFF
--- a/H5/Compiler/Compiler/Program.cs
+++ b/H5/Compiler/Compiler/Program.cs
@@ -328,6 +328,19 @@ namespace H5.Compiler
                 return true;
             }
 
+            // The mutex-guarded wait loop runs entirely on a single thread pool thread.
+            //
+            // A named Mutex has thread affinity: it must be released by the exact thread that acquired
+            // it. The previous implementation held the mutex across `await` calls, so the continuation
+            // could resume on a different thread and ReleaseMutex() then threw
+            // "Object synchronization method was called from an unsynchronized block of code."
+            // Running the whole acquire/loop/release sequence synchronously inside Task.Run keeps it
+            // pinned to one thread, so the mutex is always released by its owning thread.
+            return await Task.Run(() => WaitForCompilationServerOnline(remoteCompiler));
+        }
+
+        private static bool WaitForCompilationServerOnline(RemoteCompiler remoteCompiler)
+        {
             using var startupMutex = new Mutex(false, ServerStartupMutexName);
 
             var ownsStartupMutex = false;
@@ -351,7 +364,7 @@ namespace H5.Compiler
 
                 while (!_exitToken.IsCancellationRequested && DateTime.UtcNow < deadline)
                 {
-                    if (await IsServerOnlineAsync(remoteCompiler))
+                    if (IsServerOnline(remoteCompiler))
                     {
                         Logger.LogInformation("Found compilation server, sending compilation request\n\n");
                         return true;
@@ -365,12 +378,12 @@ namespace H5.Compiler
                         startedServer = true;
                     }
 
-                    await Task.Delay(ServerPollIntervalMs, _exitToken.Token);
+                    if (_exitToken.Token.WaitHandle.WaitOne(ServerPollIntervalMs))
+                    {
+                        // Exit requested while waiting; stop and report the server as unavailable.
+                        break;
+                    }
                 }
-            }
-            catch (OperationCanceledException)
-            {
-                //Exit requested while waiting; fall through and report the server as unavailable.
             }
             finally
             {
@@ -388,6 +401,19 @@ namespace H5.Compiler
             try
             {
                 await remoteCompiler.Ping(_exitToken.Token);
+                return true;
+            }
+            catch (Exception)
+            {
+                return false;
+            }
+        }
+
+        private static bool IsServerOnline(RemoteCompiler remoteCompiler)
+        {
+            try
+            {
+                remoteCompiler.Ping(_exitToken.Token).GetAwaiter().GetResult();
                 return true;
             }
             catch (Exception)


### PR DESCRIPTION
## Summary
Refactored the compilation server startup logic to fix a thread affinity bug with named Mutex objects. The previous implementation held a Mutex across `await` calls, causing it to be released on a different thread than the one that acquired it, resulting in synchronization errors.

## Key Changes
- Extracted the mutex-guarded wait loop into a new synchronous method `WaitForCompilationServerOnline()` that runs entirely on a single thread pool thread via `Task.Run()`
- Created a new synchronous `IsServerOnline()` method that uses `GetAwaiter().GetResult()` to block on the async ping operation instead of awaiting
- Replaced `await Task.Delay()` with `_exitToken.Token.WaitHandle.WaitOne()` to perform synchronous waiting without context switching
- Replaced try-catch for `OperationCanceledException` with explicit `WaitHandle.WaitOne()` return value check for cancellation detection

## Implementation Details
- The named Mutex now has guaranteed thread affinity since the entire acquire/loop/release sequence runs synchronously on a single thread
- The synchronous wait approach prevents the async context from resuming on a different thread pool thread
- Cancellation is still properly handled through the exit token, but now detected synchronously rather than through exception handling
- The public `EnsureCompilationServerOnlineAsync()` method remains async and delegates to the synchronous implementation via `Task.Run()`

https://claude.ai/code/session_018Htm3FmQMQ4GgFguWfx4Pn