### PR TITLE
Add Clamp method to MathF

### DIFF
--- a/H5/H5/System/MathF.cs
+++ b/H5/H5/System/MathF.cs
@@ -98,6 +98,14 @@ namespace System
         [H5.Template("H5.Int.trunc({d})")]
         public static extern float Truncate(float d);
 
+        // Note: the real .NET System.MathF does not expose Clamp (it lives on System.Math, which
+        // has a float overload). This is an intentional H5 extension that mirrors Math.Clamp(float, float, float).
+        [H5.Template(@"(function(value, min, max) {
+            if (min > max) { throw new System.ArgumentException('min > max'); }
+            return (value < min) ? min : ((value > max) ? max : value);
+        })({value}, {min}, {max})")]
+        public static extern float Clamp(float value, float min, float max);
+
         [H5.Template("((1.0 / {y}) < 0 ? -1.0 : 1.0) * Math.abs({x})")]
         public static extern float CopySign(float x, float y);
 

--- a/Tests/H5.Compiler.IntegrationTests/StandardLibrary/MathFTests.cs
+++ b/Tests/H5.Compiler.IntegrationTests/StandardLibrary/MathFTests.cs
@@ -159,5 +159,38 @@ public class Program
 }
                 ");
         }
+
+        [TestMethod]
+        public async Task TestClampAsync()
+        {
+            // MathF.Clamp is an H5 extension (the real .NET MathF has no Clamp; it lives on Math).
+            // Compare H5's MathF.Clamp output against .NET's Math.Clamp(float, ...) for parity.
+            await RunTest(
+                @"
+using System;
+
+public class Program
+{
+    public static void Main()
+    {
+                Console.WriteLine(MathF.Clamp(5.0f, 1.0f, 10.0f).ToString(""F1"")); // within range => 5
+                Console.WriteLine(MathF.Clamp(-5.0f, 1.0f, 10.0f).ToString(""F1"")); // below min => 1
+                Console.WriteLine(MathF.Clamp(15.0f, 1.0f, 10.0f).ToString(""F1"")); // above max => 10
+    }
+}",
+                overrideRoslynCode:
+                @"
+using System;
+
+public class Program
+{
+    public static void Main()
+    {
+                Console.WriteLine(Math.Clamp(5.0f, 1.0f, 10.0f).ToString(""F1""));
+                Console.WriteLine(Math.Clamp(-5.0f, 1.0f, 10.0f).ToString(""F1""));
+                Console.WriteLine(Math.Clamp(15.0f, 1.0f, 10.0f).ToString(""F1""));
+    }
+}");
+        }
     }
 }


### PR DESCRIPTION
## Summary

Adds a `float Clamp(float value, float min, float max)` to `System.MathF`, mirroring the existing `Math.Clamp(float, float, float)`.

The `MathF` class already exists in the core library (mirroring `Math` for `float` and routing to the same underlying JS/`H5.Math` helpers). This PR fills the one gap where `Math` offers a `float` overload that `MathF` lacked.

Note: the real .NET `System.MathF` does **not** expose `Clamp` (in the BCL it lives only on `System.Math`, which has a `float` overload). This is therefore an intentional H5 extension. The `[H5.Template]` reuses the exact same JavaScript body as `Math.Clamp`, including the `min > max` `ArgumentException` guard, so behavior is consistent with the existing implementation.

## Changes

- `H5/H5/System/MathF.cs` — add `MathF.Clamp(float, float, float)` with a template matching `Math.Clamp`.
- `Tests/H5.Compiler.IntegrationTests/StandardLibrary/MathFTests.cs` — add `TestClampAsync`, which compiles `MathF.Clamp` via H5 and compares its output against real .NET `Math.Clamp` (via `overrideRoslynCode`) for parity across the in-range, below-min, and above-max cases.

## Testing

- Built the H5 core library with the h5 transpiler (`dotnet build`) — succeeds with 0 warnings/errors.
- Ran the `MathFTests` integration suite against the local build — all 8 tests pass (7 pre-existing + the new `TestClampAsync`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015C6Apr56J7FTcfnvE6X9NS

---
_Generated by [Claude Code](https://claude.ai/code/session_015C6Apr56J7FTcfnvE6X9NS)_