### PR TITLE
Add deprecation notice for h5 in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+> **⚠️ h5 has been replaced by [Transpose](https://github.com/curiosity-ai/transpose).** Transpose is the next generation of h5, rebuilt around Roslyn. New projects should start there.
+>
+> - Repo: https://github.com/curiosity-ai/transpose
+> - Packages: [Transpose.BCL](https://www.nuget.org/packages/Transpose.BCL/) · [Transpose.Core](https://www.nuget.org/packages/Transpose.Core/) · [Transpose.Build.Target](https://www.nuget.org/packages/Transpose.Build.Target/) · [Transpose.Newtonsoft.Json](https://www.nuget.org/packages/Transpose.Newtonsoft.Json/) · [Transpose.Template](https://www.nuget.org/packages/Transpose.Template/) · [Transpose.Compiler.Library](https://www.nuget.org/packages/Transpose.Compiler.Library/) · [tesserae](https://www.nuget.org/packages/tesserae/)
+> - Migration guide: https://github.com/curiosity-ai/transpose/blob/master/MIGRATION.md
+
 #  h5 🚀 - C# to JavaScript compiler
 
 <a href="https://github.com/curiosity-ai/h5"><img src="https://raw.githubusercontent.com/curiosity-ai/h5/master/logo/h5.svg" width="120" height="120" align="right" /></a>


### PR DESCRIPTION
## Summary
Added a prominent deprecation warning at the top of the README to inform users that h5 has been replaced by Transpose, the next generation compiler rebuilt around Roslyn.

## Changes
- Added a warning banner at the beginning of README.md directing users to the Transpose project
- Included links to:
  - Transpose repository
  - All relevant Transpose NuGet packages (BCL, Core, Build.Target, Newtonsoft.Json, Template, Compiler.Library, and tesserae)
  - Migration guide for existing h5 users
- Preserved all existing h5 documentation below the deprecation notice

## Details
This change ensures that new users and existing users visiting the repository are immediately aware that h5 is no longer the recommended solution and should migrate to Transpose for new projects.

https://claude.ai/code/session_01GS5RPw2yCPcMcRGWLEtqd4